### PR TITLE
Option to keep double pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 cewe2pdf
 ========
 
-A python script to turn cewe photobooks into pdf documents. The CEWE pdf export is achieved by interpreting the mcf xml-files and compiling a pdf document which looks exactly like the cewe photo book.
+A python script to turn cewe photobooks into pdf documents.
+The CEWE pdf export is achieved by interpreting the mcf xml-files 
+and compiling a pdf document which looks like the cewe photo book.
+
+There are many unsupported options, so an exact conversion cannot be guaranteed.
 
 tags: mcf2pdf, mcf_to_pdf, CEWE Fotobuch als pdf speichern, Fotobuch nach pdf exportieren, cewe Fotobuch pdf, mcf in pdf umwandeln, aus CEW-Fotobuch ein pdf machen, cewe Fotobuch pdf
 
@@ -26,7 +30,7 @@ C:\Program Files\dm\dm-Fotowelt\dm-Fotowelt.exe
 ```
 Save the file and close it.
 
-Create a nother text file called ``additionnal_fonts.txt``, but leave it empty.
+Create a nother text file called ``additional_fonts.txt``, but leave it empty.
 
 Install - Linux
 ---------------

--- a/tests/test_simpleBook.py
+++ b/tests/test_simpleBook.py
@@ -8,16 +8,22 @@ import os, os.path
 
 from cewe2pdf import convertMcf
 
-def test_simpleBook():
+def tryToBuildBook(keepDoublePages):
     inFile = str(Path(Path.cwd(), 'tests', 'unittest_fotobook.mcf'))
     outFile = str(Path(Path.cwd(), 'tests', 'unittest_fotobook.mcf.pdf'))
     if os.path.exists(outFile) == True:
         os.remove(outFile)
     assert os.path.exists(outFile) == False
-    convertMcf(inFile)
+    convertMcf(inFile, keepDoublePages)
     assert Path(outFile).exists() == True
     os.remove(outFile)
 
+def test_simpleBookSinglePage():
+    tryToBuildBook(False)
+
+def test_simpleBookDoublePage():
+    tryToBuildBook(True)
+
 if __name__ == '__main__':
     #only executed when this file is run directly.
-    test_simpleBook()
+    test_simpleBookSinglePage()


### PR DESCRIPTION
Added an command-line option to keep double pages as as single page in the pdf.
Also fixed character encoding issues for UTF-8 input .mcf files.