### PR TITLE
Handle font, size, etc changes correctly within one text area

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ nosetests.xml
 /cewe2pdf - Copy.py
 /examples.xml
 /cewe2pdf.pyproj.user
+/tests/unittest_fotobook.mcf.pdf
+*.mcf~
+*.xml~
+/tests/unittest_fotobook_mcf-Dateien/identifier.xml

--- a/additional_fonts.txt
+++ b/additional_fonts.txt
@@ -1,2 +1,7 @@
 Arial = C:\WINDOWS\FONTS\ARIAL.TTF
 Arial Rounded MT Bold = C:\WINDOWS\FONTS\ARLRDBD.TTF
+Bodoni = C:\Windows\Fonts\BOD_R.TTF
+Stafford = C:\Windows\Fonts\times.ttf
+CalligraphScript = C:\Windows\Fonts\PALSCRI.TTF
+FranklinGothic = C:\Windows\Fonts\framd.ttf
+Calibri = C:\Windows\Fonts\calibri.ttf

--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -426,8 +426,7 @@ def processAreaTextTag(textTag, additionnal_fonts, area, areaHeight, areaRot, ar
 
         paragraphText += '</para>'
 
-        pdf_styleN.fontSize = maxfs
-        pdf_styleN.leading = pdf_styleN.fontSize * line_scale  # line spacing (text + leading)
+        pdf_styleN.leading = maxfs * line_scale  # line spacing (text + leading)
 
         pdf_flowableList.append(Paragraph(paragraphText, pdf_styleN))
 

--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -49,6 +49,7 @@ import sys
 from lxml import etree
 import tempfile
 from math import sqrt, floor
+import html
 
 from reportlab.pdfgen import canvas
 import reportlab.lib.pagesizes
@@ -297,11 +298,10 @@ def processAreaImageTag(imageTag, area, areaHeight, areaRot, areaWidth, imagedir
         tempFileList.append(jpeg.name)
         # we can not delete now, because file is opened by pdf library
 
-def AppendText(pdf_styleN, text):
-    if text is None:
-        text = "&nbsp;"
-    newString = '<para autoLeading="max">' + text + '</para>'
-    pdf_flowableList.append(Paragraph(newString, pdf_styleN))
+def AppendText(paratext, newtext):
+    if newtext is None:
+        return paratext
+    return paratext + newtext;
 
 def CreateParagraphStyle(backgroundColor, textcolor, font, fontsize):
     parastyle = ParagraphStyle(None, None,
@@ -320,21 +320,22 @@ def CreateParagraphStyle(backgroundColor, textcolor, font, fontsize):
 
 def processAreaTextTag(textTag, additionnal_fonts, area, areaHeight, areaRot, areaWidth, pdf, transx, transy):
     # note: it would be better to use proper html processing here
-    html = etree.XML(textTag.text)
-    body = html.find('.//body')
+    htmlxml = etree.XML(textTag.text)
+    body = htmlxml.find('.//body')
     bstyle = dict([kv.split(':') for kv in
                     body.get('style').lstrip(' ').rstrip(';').split('; ')])
     family = bstyle['font-family'].strip("'")
     font = 'Helvetica'
     try:
-        fs = int(bstyle['font-size'].strip("pt"))
+        bodyfs = floor(float(bstyle['font-size'].strip("pt")))
     except:
-        fs = 20
+        bodyfs = 20
     if family in pdf.getAvailableFonts():
         font = family
     elif family in additionnal_fonts:
         font = family
-    color = '#000000'  
+    color = '#000000' 
+    maxfs = bodyfs
 
     pdf.translate(transx, transy)
     pdf.rotate(-areaRot)
@@ -346,17 +347,32 @@ def processAreaTextTag(textTag, additionnal_fonts, area, areaHeight, areaRot, ar
         backgroundColor = reportlab.lib.colors.HexColor(backgroundColorAttrib)
     
     # set default para style in case there are no spans to set it
-    pdf_styleN = CreateParagraphStyle(backgroundColor, reportlab.lib.colors.black, font, fs)
+    pdf_styleN = CreateParagraphStyle(backgroundColor, reportlab.lib.colors.black, font, bodyfs)
+
+    ################
+    # potential killer here .. the leading for the paragraph is set on the basis of the bodyfs and will
+    # not be changed as the size of the text changes! So the lines of the paragraph can collide
+    # or be too widely spaced for the font size as that size changes through the paragraph.
+    ################
+
+    # pdf_styleN.backColor = reportlab.lib.colors.HexColor("0xFFFF00") # for debuging useful
     
     htmlparas = body.findall(".//p")
     for p in htmlparas:
+        if p.get('align') == 'center':
+            pdf_styleN.alignment = reportlab.lib.enums.TA_CENTER
+        elif p.get('align') == 'right':
+            pdf_styleN.alignment = reportlab.lib.enums.TA_RIGHT
+        else:
+            pdf_styleN.alignment = reportlab.lib.enums.TA_LEFT
+        paragraphText = '<para autoLeading="max">'
         htmlspans = p.findall(".//span")
         if (len(htmlspans) < 1): 
             # append the paragraph text, accepting whatever format is valid now
             if (p.text == None):
-                AppendText(pdf_styleN, "&nbsp;<br />")
+                paragraphText = AppendText(paragraphText, "<br></br>")
             else:
-                AppendText(pdf_styleN, p.text)
+                paragraphText = AppendText(paragraphText, html.escape(p.text))
         else:
             for span in htmlspans:
                 spanfont = font
@@ -373,28 +389,48 @@ def processAreaTextTag(textTag, additionnal_fonts, area, areaHeight, areaRot, ar
                         print("Using font family = '%s' (wanted %s)" % (
                             spanfont, spanfamily))
                 if 'font-size' in style:
-                    fs = int(style['font-size'].strip()[:-2])
+                    spanfs = floor(float(style['font-size'].strip("pt")))
+                else:
+                    spanfs = bodyfs
+                if spanfs > maxfs:
+                    maxfs = spanfs
+
                 if 'color' in style:
                     color = style['color']
-                pdf_styleN = CreateParagraphStyle(backgroundColor, reportlab.lib.colors.HexColor(color), spanfont, fs)
-                if p.get('align') == 'center':
-                    pdf_styleN.alignment = reportlab.lib.enums.TA_CENTER
-                elif p.get('align') == 'right':
-                    pdf_styleN.alignment = reportlab.lib.enums.TA_RIGHT
-                else:
-                    pdf_styleN.alignment = reportlab.lib.enums.TA_LEFT
-                # add some flowables
-                # pdf_styleN.backColor = reportlab.lib.colors.HexColor("0xFFFF00") # for debuging useful
                 
+                paragraphText = AppendText(paragraphText, '<span name="' + spanfont + '"'
+                    ' color=' + color +
+                    ' size=' + str(spanfs)
+                    )
+
+                if (backgroundColorAttrib is not None):
+                    paragraphText = AppendText(paragraphText, ' backcolor=' + backgroundColorAttrib)
+                    #'style=' + stylename +
+                
+                paragraphText = AppendText(paragraphText, '>')
+                                
                 # append the text of the span
-                AppendText(pdf_styleN, span.text)
+                paragraphText = AppendText(paragraphText, html.escape(span.text))
 
                 # if there are line breaks in the span then we must pick up the following texts
                 brs = span.findall(".//br")
                 if len(brs) > 0:
                     for br in brs:
-                        AppendText(pdf_styleN, br.tail)
-    
+                        paragraphText = AppendText(paragraphText, "<br></br>")
+                        paragraphText = AppendText(paragraphText, br.tail)
+
+                paragraphText = AppendText(paragraphText, '</span>')
+
+                if (span.tail != None):
+                    paragraphText = AppendText(paragraphText, html.escape(span.tail))
+
+        paragraphText += '</para>'
+
+        pdf_styleN.fontSize = maxfs
+        pdf_styleN.leading = pdf_styleN.fontSize * line_scale  # line spacing (text + leading)
+
+        pdf_flowableList.append(Paragraph(paragraphText, pdf_styleN))
+
     #Add a frame object that can contain multiple paragraphs
     frameBottomLeft_x = -0.5 * f * areaWidth
     frameBottomLeft_y = -0.5 * f * areaHeight

--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -303,6 +303,21 @@ def AppendText(pdf_styleN, text):
     newString = '<para autoLeading="max">' + text + '</para>'
     pdf_flowableList.append(Paragraph(newString, pdf_styleN))
 
+def CreateParagraphStyle(backgroundColor, textcolor, font, fontsize):
+    parastyle = ParagraphStyle(None, None,
+        alignment=reportlab.lib.enums.TA_LEFT, # will often be overridden
+        fontSize=fontsize,
+        fontName=font,
+        leading=fontsize*line_scale,  # line spacing (text + leading)
+        borderPadding=0,
+        borderWidth=0,
+        leftIndent=0,
+        rightIndent=0,
+        embeddedHyphenation=1, # allow line break on existing hyphens
+        textColor=textcolor,
+        backColor=backgroundColor)
+    return parastyle
+
 def processAreaTextTag(textTag, additionnal_fonts, area, areaHeight, areaRot, areaWidth, pdf, transx, transy):
     # note: it would be better to use proper html processing here
     html = etree.XML(textTag.text)
@@ -325,26 +340,14 @@ def processAreaTextTag(textTag, additionnal_fonts, area, areaHeight, areaRot, ar
     pdf.rotate(-areaRot)
     
     #Get the background color. It is stored in an extra element.
-    backgroundColor= None
+    backgroundColor = None
     backgroundColorAttrib = area.get('backgroundcolor')
     if (backgroundColorAttrib is not None):
         backgroundColor = reportlab.lib.colors.HexColor(backgroundColorAttrib)
     
     # set default para style in case there are no spans to set it
-    pdf_styleN = ParagraphStyle(None, None,
-        alignment=reportlab.lib.enums.TA_LEFT,
-        fontSize=fs,
-        fontName=font,
-        leading=fs*line_scale,  # line spacing
-        borderPadding=0,
-        borderWidth=0,
-        leftIndent=0,
-        rightIndent=0,
-        textColor=reportlab.lib.colors.black,
-        backColor=backgroundColor
-        )
+    pdf_styleN = CreateParagraphStyle(backgroundColor, reportlab.lib.colors.black, font, fs)
     
-    #y_p = 0    #keep track of y-position for multi-line text using DrawString
     htmlparas = body.findall(".//p")
     for p in htmlparas:
         htmlspans = p.findall(".//span")
@@ -373,31 +376,12 @@ def processAreaTextTag(textTag, additionnal_fonts, area, areaHeight, areaRot, ar
                     fs = int(style['font-size'].strip()[:-2])
                 if 'color' in style:
                     color = style['color']
-                # pdf.setFont(spanfont, fs) # from old code with drawCentredString
-                # pdf.setFillColor(color) # from old code with drawCentredString
-                pdf_styleN = ParagraphStyle(None, None,
-                                            alignment=reportlab.lib.enums.TA_LEFT,
-                                            fontSize=fs,
-                                            fontName=spanfont,
-                                            leading=fs*line_scale,  # line spacing
-                                            borderPadding=0,
-                                            borderWidth=0,
-                                            leftIndent=0,
-                                            rightIndent=0,
-                                            textColor=reportlab.lib.colors.HexColor(color),
-                                            backColor=backgroundColor
-                                            )
+                pdf_styleN = CreateParagraphStyle(backgroundColor, reportlab.lib.colors.HexColor(color), spanfont, fs)
                 if p.get('align') == 'center':
-                    #    pdf.drawCentredString(0,
-                    #        0.5 * f * areaHeight + y_p -1.3*fs, span.text)
                     pdf_styleN.alignment = reportlab.lib.enums.TA_CENTER
                 elif p.get('align') == 'right':
-                    #    pdf.drawRightString(0.5 * f * areaWidth,
-                    #        0.5 * f * areaHeight + y_p -1.3*fs, span.text)
                     pdf_styleN.alignment = reportlab.lib.enums.TA_RIGHT
                 else:
-                    #    pdf.drawString(-0.5 * f * areaWidth,
-                    #        0.5 * f * areaHeight + y_p -1.3*fs, span.text)
                     pdf_styleN.alignment = reportlab.lib.enums.TA_LEFT
                 # add some flowables
                 # pdf_styleN.backColor = reportlab.lib.colors.HexColor("0xFFFF00") # for debuging useful
@@ -411,7 +395,6 @@ def processAreaTextTag(textTag, additionnal_fonts, area, areaHeight, areaRot, ar
                     for br in brs:
                         AppendText(pdf_styleN, br.tail)
     
-        #y_p -= 1.3*fs
     #Add a frame object that can contain multiple paragraphs
     frameBottomLeft_x = -0.5 * f * areaWidth
     frameBottomLeft_y = -0.5 * f * areaHeight

--- a/tests/test_simpleBook.py
+++ b/tests/test_simpleBook.py
@@ -27,7 +27,7 @@ def tryToBuildBook(keepDoublePages):
     else:
         assert numPages == 28
 
-    os.remove(outFile)
+    #os.remove(outFile)
 
 def test_simpleBookSinglePage():
     tryToBuildBook(False)
@@ -37,5 +37,5 @@ def test_simpleBookDoublePage():
 
 if __name__ == '__main__':
     #only executed when this file is run directly.
-    #test_simpleBookSinglePage()
-    test_simpleBookDoublePage();
+    test_simpleBookSinglePage()
+    #test_simpleBookDoublePage();


### PR DESCRIPTION
Use a single paragraph per text area. This is not good enough, because the line spacing (leading) can only have one value per paragraph. But it is better than the previous version which ended up creating a new paragraph per span (colour change, size change, whatever).
The unit test is now "better", but not ok yet
My 10 existing albums seem ok, so I don't think I have broken anything fundamental 