### PR TITLE
Fixes, finally, the line spacing (leading) problem

### DIFF
--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -423,7 +423,6 @@ def processAreaTextTag(textTag, additionnal_fonts, area, areaHeight, areaRot, ar
     except:
         bweight = 400
     color = '#000000' 
-    maxfs = bodyfs
 
     pdf.translate(transx, transy)
     pdf.rotate(-areaRot)
@@ -447,6 +446,8 @@ def processAreaTextTag(textTag, additionnal_fonts, area, areaHeight, areaRot, ar
     
     htmlparas = body.findall(".//p")
     for p in htmlparas:
+        maxfs = bodyfs # reset to body font size for each paragraph
+
         if p.get('align') == 'center':
             pdf_styleN.alignment = reportlab.lib.enums.TA_CENTER
         elif p.get('align') == 'right':


### PR DESCRIPTION
After all the general corrections for formatting, this is the one that fixes the leading problems that have confused us, by resetting the max font size (which we use to set the leading) to the body font size for *each paragraph*. If you use enter to start a new line in your text (rather than shift-enter) then things look good. If you use shift-enter to get a new line within one paragraph then all the lines in the paragraph will be leaded for the maximum font size found in that paragraph