### PR TITLE
Fix "is not" comparison warning.

### DIFF
--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -461,7 +461,7 @@ def processAreaDecorationTag(decoration, areaHeight, areaWidth, pdf):
     for border in decoration.findall('border'):
         if "enabled" in border.attrib:
             enabledAttrib = border.get('enabled')
-            if (enabledAttrib is not '1'):
+            if (enabledAttrib != '1'):
                 return
 
         bwidth = 1


### PR DESCRIPTION
Fix this warning under Python 3.8:
`./cewe2pdf.py:464: SyntaxWarning: "is not" with a literal. Did you mean "!="?`