### PR TITLE
Move towards lint free code, using pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,592 @@
+# Pylint configuration initially generated with pylint --generate-rcfile > .pylintrc
+# See https://docs.microsoft.com/en-us/visualstudio/python/linting-python-code?view=vs-2019
+
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=
+
+# Specify a score threshold to be exceeded before program exits with error.
+fail-under=10.0
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        deprecated-operator-function,
+        deprecated-urllib-function,
+        xreadlines-attribute,
+        deprecated-sys-function,
+        exception-escape,
+        comprehension-escape,
+        invalid-name
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'error', 'warning', 'refactor', and 'convention'
+# which contain the number of messages in each category, as well as 'statement'
+# which is the total number of statements analyzed. This score is used by the
+# global evaluation report (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+#notes-rgx=
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it work,
+# install the python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "BaseException, Exception".
+overgeneral-exceptions=BaseException,
+                       Exception

--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-
 '''
 Create pdf files from CEWE .mcf photo books (cewe-fotobuch)
 version 0.11 (Dec 2019)
@@ -56,7 +55,7 @@ if hasattr(sys, 'frozen'):
     dllpath = os.path.dirname(os.path.realpath(sys.argv[0]))
     if dllpath not in os.environ:
         os.environ["PATH"] += os.pathsep + dllpath
-        
+
 from lxml import etree
 import tempfile
 from math import sqrt, floor
@@ -157,9 +156,9 @@ def findFileByExtInDirs(filebase, extList, paths):
 def findFileInDirs(filenames, paths):
     if not isinstance(filenames, list):
         filenames = [filenames]
-    for f in filenames:
+    for filename in filenames:
         for p in paths:
-            testPath = os.path.join(p, f)
+            testPath = os.path.join(p, filename)
             if os.path.exists(testPath):
                 return testPath
 
@@ -173,7 +172,7 @@ def getPageElementForPageNumber(fotobook, pageNumber):
 
 # This is only used for the <background .../> tags. The stock backgrounds use this element.
 def processBackground(backgroundTags, bg_notFoundDirList, cewe_folder, backgroundLocations, keepDoublePages, oddpage, pagetype, pdf, ph, pw):
-    if (pagetype == "emptypage"):  # don't draw background for the empty pages. That is page nr. 1 and pageCount-1.
+    if pagetype == "emptypage":  # don't draw background for the empty pages. That is page nr. 1 and pageCount-1.
         return
     if backgroundTags != None and len(backgroundTags) > 0:
         # look for a tag that has an alignment attribute
@@ -286,7 +285,7 @@ def processAreaImageTag(imageTag, area, areaHeight, areaRot, areaWidth, imagedir
             print("Regenerating passepartout index from .XML files.")
             global passepartoutFolders
             passepartoutDict = Passepartout.buildElementIdIndex(passepartoutFolders)
-        # read information from .xml file        
+        # read information from .xml file
         try:
             pptXmlFileName = passepartoutDict[passepartoutid]
         except:
@@ -307,7 +306,7 @@ def processAreaImageTag(imageTag, area, areaHeight, areaRot, areaWidth, imagedir
             frameDeltaY_mcfunit = pptXmlInfo.fotoarea_y * areaHeight
             imgCropWidth_mcfunit = pptXmlInfo.fotoarea_width * areaWidth
             imgCropHeight_mcfunit = pptXmlInfo.fotoarea_height * areaHeight
-            
+
     # without cropping: to get from a image pixel width to the areaWidth in .mcf-units, the image pixel width is multiplied by the scale factor.
     # to get from .mcf units are divided by the scale factor to get to image pixel units.
 
@@ -317,9 +316,9 @@ def processAreaImageTag(imageTag, area, areaHeight, areaRot, areaWidth, imagedir
     # For normal image display without passepartout there should be no black pixels visible,
     # because the CEWE software doesn't allow the creation of such parameters that would result in them.
     # For frames, the situation might arrise, but then the mask is applied.
-    
+
     #first calcualte cropping coordinate for normal case
-    cropLeft =  int(0.5 - imleft/imScale + 0*frameDeltaX_mcfunit/imScale)    
+    cropLeft =  int(0.5 - imleft/imScale + 0*frameDeltaX_mcfunit/imScale)
     cropUpper = int(0.5 - imtop/imScale + 0*frameDeltaY_mcfunit/imScale)
     cropRight = int(0.5 - imleft/imScale + 0*frameDeltaX_mcfunit/imScale + imgCropWidth_mcfunit / imScale)
     cropLower = int(0.5 - imtop/imScale + 0*frameDeltaY_mcfunit/imScale + imgCropHeight_mcfunit / imScale)
@@ -345,7 +344,7 @@ def processAreaImageTag(imageTag, area, areaHeight, areaRot, areaWidth, imagedir
 
     #apply the frame mask from the passepartout to the image
     if not (maskClipartFileName is None):
-        maskClp = loadClipart(maskClipartFileName) 
+        maskClp = loadClipart(maskClipartFileName)
         im = maskClp.applyAsAlphaMaskToFoto(im)
 
     # re-compress image
@@ -357,7 +356,7 @@ def processAreaImageTag(imageTag, area, areaHeight, areaRot, areaWidth, imagedir
     else:
         im.save(jpeg.name, "JPEG",
                 quality=image_quality)
-    
+
     # place image
     print('image', imageTag.get('filename'))
     pdf.translate(img_transx, transy)   #we need to go to the center for correct rotation
@@ -377,12 +376,12 @@ def processAreaImageTag(imageTag, area, areaHeight, areaRot, areaWidth, imagedir
     #we need to draw our passepartout after the real image, so it overlays it.
     if not (frameClipartFileName is None):
         # we set the transx, transy, and areaRot for the clipart to zero, because our current pdf object
-        # already has these transformations applied. So don't do it twice. 
+        # already has these transformations applied. So don't do it twice.
         insertClipartFile(frameClipartFileName, 0, areaWidth, areaHeight, frameAlpha, pdf, 0, 0)
 
     for decorationTag in area.findall('decoration'):
         processAreaDecorationTag(decorationTag, areaHeight, areaWidth, pdf)
-    
+
     pdf.rotate(areaRot)
     pdf.translate(-img_transx, -transy)
 
@@ -493,7 +492,7 @@ def CollectFontInfo(item, pdf, additionnal_fonts, dfltfont, dfltfs, bweight):
 
 def AppendSpanStart(paragraphText, bgColorAttrib, font, fsize, fweight, fstyle, outerstyle):
     """
-    Remember this is not really HTML, though it looks that way. 
+    Remember this is not really HTML, though it looks that way.
     See 6.2 Paragraph XML Markup Tags in the reportlabs user guide.
     """
     paragraphText = AppendText(paragraphText, '<font name="' + font + '"'
@@ -568,7 +567,7 @@ def processAreaDecorationTag(decoration, areaHeight, areaWidth, pdf):
                 adjustment = 0
             if (positionAttrib == "outside"):
                 adjustment = bwidth * 0.5
-        
+
         frameBottomLeft_x = -0.5 * (f * areaWidth) - adjustment
         frameBottomLeft_y = -0.5 * (f * areaHeight) - adjustment
         frameWidth = f * areaWidth + 2 * adjustment
@@ -587,7 +586,7 @@ def processAreaDecorationTag(decoration, areaHeight, areaWidth, pdf):
         )
         frm_table.wrapOn(pdf, frameWidth, frameHeight)
         frm_table.drawOn(pdf, frameBottomLeft_x, frameBottomLeft_y)
-        
+
         return
 
 
@@ -727,7 +726,7 @@ def processAreaTextTag(textTag, additionnal_fonts, area, areaHeight, areaRot, ar
                 print('Error:', ex.args[0])
                 exc_type, exc_obj, exc_tb = sys.exc_info()
                 fname = os.path.split(exc_tb.tb_frame.f_code.co_filename)[1]
-                print('', (exc_type, fname, exc_tb.tb_lineno))        
+                print('', (exc_type, fname, exc_tb.tb_lineno))
 
 
     # Add a frame object that can contain multiple paragraphs
@@ -756,11 +755,11 @@ def processAreaTextTag(textTag, additionnal_fonts, area, areaHeight, areaRot, ar
             # I have never seen this happen, but check anyway
             print('Warning: A set of paragraphs too wide for its frame. INTERNAL ERROR!')
             finalTotalWidth = neededTextWidth + leftPad + rightPad 
-    
+
     if finalTotalHeight > frameHeight:
-        # One of the possible causes here is that wrap function has used an extra line (because 
+        # One of the possible causes here is that wrap function has used an extra line (because
         #  of some slight mismatch in character widths and a frame that matches too precisely?)
-        #  so that a word wraps over when it shouldn't. I don't know how to fix that sensibly. 
+        #  so that a word wraps over when it shouldn't. I don't know how to fix that sensibly.
         #  Increasing the height is NOT a good visual solution, because the line wrap is still
         #  not where the user expects it - increasing the width would almost be more sensible!
         # Another suspected cause is in the use of multiple font sizes in one text. Perhaps the
@@ -784,7 +783,7 @@ def processAreaTextTag(textTag, additionnal_fonts, area, areaHeight, areaRot, ar
     # We took care of this by making the frame so large, that it always can fit the flowables.
     # maybe should switch to res=newFrame.split(flowable, pdf) and check the result manually.
     newFrame.addFromList(pdf_flowableList, pdf)
-            
+
     for decorationTag in area.findall('decoration'):
         processAreaDecorationTag(decorationTag, areaHeight, areaWidth, pdf)
 
@@ -802,8 +801,8 @@ def loadClipart(fileName) -> ClpFile :
         if not filePath.exists():
             filePath = filePath.parent.joinpath(filePath.stem+".clp")
             if not filePath.exists():
-                print("Error: missing .clp: {}".format(fileName))   
-                return ClpFile("")   #return an empty ClpFile             
+                print("Error: missing .clp: {}".format(fileName))
+                return ClpFile("")   #return an empty ClpFile
     else:
         pathObj = Path(fileName)
         baseFileName = pathObj.stem
@@ -811,8 +810,8 @@ def loadClipart(fileName) -> ClpFile :
             filePath = findFileInDirs([baseFileName+'.clp', baseFileName+'.svg'], clipartPathList)
             filePath = Path(filePath)
         except Exception as ex:
-            print("Error: {}, {}".format(baseFileName, ex)) 
-            return ClpFile("")   #return an empty ClpFile             
+            print("Error: {}, {}".format(baseFileName, ex))
+            return ClpFile("")   #return an empty ClpFile
 
     if (filePath.suffix == '.clp'):
         newClpFile.readClp(filePath)
@@ -853,7 +852,7 @@ def insertClipartFile(fileName:str, transx, areaWidth, areaHeight, alpha, pdf, t
     if len(clipart.svgData) <= 0:
         print('Clipart file could not be loaded:', fileName)
         # avoiding exception in the processing below here
-        return 
+        return
 
     clipart.convertToPngInBuffer(new_w, new_h, alpha)  #so we can access the pngMemFile later
 
@@ -986,10 +985,10 @@ def readClipArtConfigXML(baseFolder):
     clipArtXml.close()
 
     for decoration in xmlInfo.findall('decoration'):
-            clipartElement = decoration.find('clipart')
-            fileName = clipartElement.get('file')
-            designElementId = int(clipartElement.get('designElementId'))    #assume these IDs are always integers. 
-            clipartDict[designElementId] = fileName
+        clipartElement = decoration.find('clipart')
+        fileName = clipartElement.get('file')
+        designElementId = int(clipartElement.get('designElementId'))    #assume these IDs are always integers.
+        clipartDict[designElementId] = fileName
     return
 
 def getBaseBackgroundLocations(basefolder):
@@ -1011,7 +1010,7 @@ def SetEnvironmentVariables(cewe_folder, defaultConfigSection):
         karoot = katree.getroot()
         ka = karoot.find('keyAccount').text # that's the official installed value
         # see if he has a .ini file override for the keyaccount
-        inika = defaultConfigSection.get('keyaccount');
+        inika = defaultConfigSection.get('keyaccount')
         if not inika is None:
             print('ini file overrides keyaccount from {} to {}'.format(ka, inika))
             ka = inika
@@ -1056,7 +1055,7 @@ def convertMcf(mcfname, keepDoublePages: bool):
         #  overwritten when they appear in the later config files.
         # We want the config file in the .mcf directory to be the most important file.
         filesread = configuration.read(['cewe2pdf.ini', os.path.join(mcfBaseFolder, 'cewe2pdf.ini')])
-        if len(filesread) < 1: 
+        if len(filesread) < 1:
             print('Cannot find cewe installation folder cewe_folder from cewe2pdf.ini')
             cewe_folder = None
         else:
@@ -1066,7 +1065,7 @@ def convertMcf(mcfname, keepDoublePages: bool):
             # find cewe folder from ini file
             cewe_folder = defaultConfigSection['cewe_folder'].strip()
 
-            # set the cewe folder and key account number into the environment for use in other config files 
+            # set the cewe folder and key account number into the environment for use in other config files
             SetEnvironmentVariables(cewe_folder, defaultConfigSection)
 
             baseBackgroundLocations = getBaseBackgroundLocations(cewe_folder)
@@ -1084,9 +1083,9 @@ def convertMcf(mcfname, keepDoublePages: bool):
             for ca in f2xca:
                 definition = ca.split(',')
                 if (len(definition) == 2):
-                    id = int(definition[0])
+                    clipartId = int(definition[0])
                     file = definition[1].strip()
-                    clipartDict[id] = file
+                    clipartDict[clipartId] = file
 
 
              # read passepartout folders and substitute environment variables

--- a/cewe2pdf.pyproj
+++ b/cewe2pdf.pyproj
@@ -22,6 +22,7 @@
     <VisualStudioVersion Condition=" '$(VisualStudioVersion)' == '' ">10.0</VisualStudioVersion>
   </PropertyGroup>
   <ItemGroup>
+    <Content Include=".pylintrc" />
     <Content Include="additional_fonts.txt" />
     <Content Include="build_a_compiled_version.md" />
     <Content Include="cewe2pdf.ini" />

--- a/clpFile.py
+++ b/clpFile.py
@@ -9,6 +9,7 @@ import PIL
 from PIL import ImageOps
 from PIL.ExifTags import TAGS
 from io import BytesIO
+import re
 
 class ClpFile(object):
     def __init__(self, clpFileName:str =""):
@@ -155,6 +156,32 @@ class ClpFile(object):
         svgFile = open(inputFileSVG,"rb") #input file should be UTF-8 encoded
         self.svgData = svgFile.read()
         svgFile.close()
+        return self
+    
+    def replaceColors(self, colorReplacementList):
+        """ Replace colors in the clipart
+
+        This does a simple text replacement of color strings in the clipart.
+        
+        colorReplacementList: list of tuples
+            first element of tuple: original color
+            second element: new color
+
+        The color must be a string, and it must be exactly as it appears in the .SVG file as text.
+        """
+
+        #the colors are in the form of: style="fill:#112233", or style="opacity:0.40;fill:#112233"
+        #Maybe a regex would be better, as not to replace arbitrary text
+
+        for curReplacement in colorReplacementList:
+            #print (curReplacement)
+            oldColorString = 'fill:'+curReplacement[0]
+            newColorString = 'fill:'+curReplacement[1]
+            # a general replace would look like this:
+            #     re.sub("(style=\".*?)(fill:\#[0-9a-fA-F]+)(.*?\")", r"\1"+XXX+r"\3", self.svgData)
+            self.svgData  = re.sub("(style=\".*?)("+oldColorString+")(.*?\")", r"\1"+newColorString+r"\3",  self.svgData.decode()).encode(encoding="utf-8")
+            # Old, simple, but buggy code: self.svgData = self.svgData.replace(oldColorString.encode(encoding="utf-8"),newColorString.encode(encoding="utf-8") )
+            
         return self
 
     @staticmethod

--- a/clpFile.py
+++ b/clpFile.py
@@ -21,9 +21,9 @@ class ClpFile(object):
 
     def readClp(self, fileName) -> None:
         """Read a .CLP file and convert it to a .SVG file.
-         
+
          reads the data into the internal buffer as SVG
-        
+
          Remarks: The current implementation using immutable strings may not be best.
            But it should work for typical cliparts with a size of less then a few megabytes."""
 
@@ -32,7 +32,7 @@ class ClpFile(object):
         fileClp = open(inFilePath,"rt")
         contents = fileClp.read()
         fileClp.close()
-    
+
         #check the header
         if (contents[0] != 'a'):
             raise Exception("A .cpl file should start with character 'a', but instead it was: {} ({})".format(contents[0], hex(ord(contents[0]))))
@@ -43,8 +43,8 @@ class ClpFile(object):
         #the string is hexadecimal representation of the real data. Let's convert it back.
         svgData = bytes.fromhex(hexData)
         self.svgData = svgData
-    
-        
+
+
     def saveToSVG(self, outfileName):
         """save internal SVG data to a file"""
         outFile = open(outfileName,"wb")
@@ -56,7 +56,7 @@ class ClpFile(object):
 
         #create a byte buffer that can be used like a file and use it as the output of svg2png.
         scaledImage = self.rasterSvgData(width, height)
-        
+
         if (scaledImage.mode == "RGB"):
             # create a mask the same size as the original. For all pixels which are
             # non zero ("not used") set the mask value to the required transparency
@@ -82,7 +82,7 @@ class ClpFile(object):
         #2. calculate the scaling in x-, and y-direction that is needed
         #3. use the maxium of these x-, and y-scaling and do a aspect-ratio-preserving scaling of the image
         #   convert the image again from svg to png with this max. scale factor
-        #4. do a raster-image scaling to skew the image to the final dimension. 
+        #4. do a raster-image scaling to skew the image to the final dimension.
         #   This should only scale in x- or y-direction, as the other direction should alread be the desired one.
 
         #create a byte buffer that can be used like a file and use it as the output of svg2png.
@@ -130,18 +130,18 @@ class ClpFile(object):
         if (maskImgPng.mode == "RGBA"):
             alphaChannel = maskImgPng.getchannel("A")
         elif (maskImgPng.mode == "RGB"):
-             # convert image to gray-scale and use that as alpha channel.
-             # we need to invert, otherwise black whould be transparent.
-             # normally the whole image is a black rectangle
-             alphaChannel = maskImgPng.convert('L')
-             alphaChannel = PIL.ImageOps.invert(alphaChannel)
-        
+            # convert image to gray-scale and use that as alpha channel.
+            # we need to invert, otherwise black whould be transparent.
+            # normally the whole image is a black rectangle
+            alphaChannel = maskImgPng.convert('L')
+            alphaChannel = PIL.ImageOps.invert(alphaChannel)
+
         #apply it the input photo. They must have the same dimensions. But that is ensured by rasterSvgData
         if (photo.mode != "RGB") or (photo.mode != "RGBA"):
             photo = photo.convert("RGBA")
         photo.putalpha(alphaChannel)
-        
-        return photo    
+
+        return photo
 
     def savePNGfromBufferToFile(self, fileName) -> None:
         """ write the internal PNG buffer to a file """
@@ -151,7 +151,7 @@ class ClpFile(object):
         self.pngMemFile.seek(0) # reset file pointer back to the start for other function calls
 
     def loadFromSVG(self, inputFileSVG:str):
-        #read SVG file into memory        
+        #read SVG file into memory
         svgFile = open(inputFileSVG,"rb") #input file should be UTF-8 encoded
         self.svgData = svgFile.read()
         svgFile.close()
@@ -165,7 +165,7 @@ class ClpFile(object):
         if (not outputFileCLP): #check for None and empty string
             outputFileCLP = Path(inFilePath.parent).joinpath(inFilePath.stem + ".clp")
 
-        #read SVG into memory        
+        #read SVG into memory
         svgFile = open(inFilePath,"rt")
         contents = svgFile.read()
         svgFile.close()

--- a/passepartout.py
+++ b/passepartout.py
@@ -43,7 +43,7 @@ class Passepartout(object):
             print("Error while parsing. Maybe not valid XML:{}".format(xmlFileName))
             return None
         finally:
-            clipArtXml.close()        
+            clipArtXml.close()
 
         for decoration in xmlInfo.findall('decoration'):
             # assume these IDs are always integers.
@@ -111,22 +111,22 @@ class Passepartout(object):
                 passepartoutIdDict[xmlInfo.designElementId] = curXmlFile
 
         return passepartoutIdDict
-    
-    @staticmethod
-    def getPassepartoutFileFullName(xmlInfo:decorationXmlInfo, fileName:str) -> str:   
-            pathObj = Path(xmlInfo.srcXmlFile)
-            #should not be needed: pathObj = pathObj.resolve()    # convert it to an absolute path
-            basePath = pathObj.parent
-            fullPath = basePath.joinpath(fileName)
-            return (str(fullPath))
 
     @staticmethod
-    def getClipartFullName(xmlInfo:decorationXmlInfo) -> str:        
-            return Passepartout.getPassepartoutFileFullName(xmlInfo, xmlInfo.clipartFile)
+    def getPassepartoutFileFullName(xmlInfo:decorationXmlInfo, fileName:str) -> str:
+        pathObj = Path(xmlInfo.srcXmlFile)
+        #should not be needed: pathObj = pathObj.resolve()    # convert it to an absolute path
+        basePath = pathObj.parent
+        fullPath = basePath.joinpath(fileName)
+        return (str(fullPath))
 
     @staticmethod
-    def getMaskFullName(xmlInfo:decorationXmlInfo) -> str:        
-            return Passepartout.getPassepartoutFileFullName(xmlInfo, xmlInfo.maskFile)
+    def getClipartFullName(xmlInfo:decorationXmlInfo) -> str:
+        return Passepartout.getPassepartoutFileFullName(xmlInfo, xmlInfo.clipartFile)
+
+    @staticmethod
+    def getMaskFullName(xmlInfo:decorationXmlInfo) -> str:
+        return Passepartout.getPassepartoutFileFullName(xmlInfo, xmlInfo.maskFile)
 
 
 if __name__ == '__main__':
@@ -139,4 +139,3 @@ if __name__ == '__main__':
     print(testId)
     print(testXmlInfo)
     print(Passepartout.getClipartFullName(testXmlInfo))
-

--- a/processManyMcfs.py
+++ b/processManyMcfs.py
@@ -13,7 +13,7 @@ def printFileName(filename):
 def main():
     args = sys.argv[1:]
     for arg in args:
-          for filename in glob(arg):
+        for filename in glob(arg):
             printFileName(filename)
 
 

--- a/tests/unittest_fotobook.mcf
+++ b/tests/unittest_fotobook.mcf
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fotobook art_id="7250" article_name="CEWE%20FOTOBOK%20Stor%20p%C3%A5%20premium%20matt%20fotopapir" externalProjectId="" folderID="9e29b965-4ee3-49c6-9a03-8f20497b87d8" imagedir="unittest_fotobook_mcf-Dateien" isDataMcf="0" productname="ALB98" startdatecalendarium="" useSpineLogo="0" version="4.0">
+<fotobook art_id="7250" article_name="CEWE%20FOTOBOK%20Stor%20p%C3%A5%20premium%20matt%20fotopapir" externalProjectId="" folderID="08049b6a-92c9-4c7b-9bba-e4ede342c757" imagedir="unittest_fotobook_mcf-Dateien" isDataMcf="0" productname="ALB98" startdatecalendarium="" useSpineLogo="0" version="4.0">
     <project createdWithHPSVersion="7.0.1" createdWithHPSVersionBuild="20191025" projectID="69675965-93ed-4a07-b25f-7dc31eedcc67" projectIDCreatedEpoch="1575196183"/>
-    <savingVersion compatibilityVersion="6.4.2" downCastedByVersion="6.4.7" programversion="7.0.4" programversionBuild="20201119" savetime="2021-01-21 21:32"/>
+    <savingVersion compatibilityVersion="6.4.2" downCastedByVersion="6.4.7" programversion="7.0.4" programversionBuild="20201119" savetime="2021-02-15 13:42"/>
     <articleConfig normalpages="26" pagenaming="1" totalpages="31"/>
     <pagenumbering bgcolor="#00000000" fontbold="0" fontfamily="Calibri" fontitalics="0" fontsize="24" format="0" margin="50" position="0" textcolor="#ff000000" textstring="%" verticalMargin="50">
         <outline width="0"/>
     </pagenumbering>
     <extra>
-        <lastTextFormat Alignment="ALIGNLEADING" IndentMargin="5" VerticalIndentMargin="5" backgroundColor="#00000000" font="Calibri,11,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0"/>
+        <lastTextFormat Alignment="ALIGNLEADING" IndentMargin="5" VerticalIndentMargin="5" backgroundColor="#00000000" font="Calibri,16,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0"/>
     </extra>
     <page designStyleID="0" pagenr="0" rotation="0" type="fullcover">
         <bundlesize height="2750" width="4290"/>
@@ -39,7 +39,7 @@
             <position height="106" left="820" rotation="270" top="1322" width="2650" zposition="7000"/>
             <decoration/>
             <text applySpotColor="0" areaTextType="spine"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'Stafford'; font-size:8pt; font-weight:600; font-style:normal;"><table style="-qt-table-type: root; margin-top:7px; margin-bottom:0px; margin-left:0px; margin-right:0px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-family:'FranklinGothic'; font-size:12pt; color:#df1900;">Front title	</span><span style=" font-size:12pt; font-weight:400; color:#000000;">Amsterdam - Baltimore - Casablanca - Danemark - Edison -<br /></span><span style=" font-family:'FranklinGothic'; font-size:12pt; color:#1b7dd4;">  Subtitle	</span><span style=" font-size:12pt; font-weight:400; color:#000000;">Florida - Gallipoli - Havanna - Italia - Jerusalem</span></p></td></tr></table></body></html>]]><outline width="0"/>
-                <textFormat Alignment="ALIGNLEADING,ALIGNVCENTER" IndentMargin="0" VerticalIndentMargin="0" backgroundColor="#00000000" font="Stafford,8,-1,5,75,0,0,0,0,0" foregroundColor="#ffffffff" hasOutline="0"/>
+                <textFormat Alignment="ALIGNVCENTER,ALIGNLEADING" IndentMargin="0" VerticalIndentMargin="0" backgroundColor="#00000000" font="Stafford,8,-1,5,75,0,0,0,0,0" foregroundColor="#ffffffff" hasOutline="0"/>
             </text>
         </area>
     </page>
@@ -239,7 +239,7 @@
                 <border applySpotColor="0" color="#ff000000" enabled="1" gap="10" position="outside" width="5"/>
             </decoration>
             <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'Calibri'; font-size:16pt; font-weight:400; font-style:normal;"><table style="-qt-table-type: root; margin-top:5px; margin-bottom:0px; margin-left:0px; margin-right:0px;"><tr><td style="border: none;"><p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000000;">kk centred text with border gg</span></p></td></tr></table></body></html>]]><outline color="#ff000000" width="0"/>
-                <textFormat Alignment="ALIGNVCENTER,ALIGNHCENTER" IndentMargin="0" VerticalIndentMargin="50" backgroundColor="#00000000" font="Calibri,16,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0"/>
+                <textFormat Alignment="ALIGNHCENTER,ALIGNVCENTER" IndentMargin="0" VerticalIndentMargin="50" backgroundColor="#00000000" font="Calibri,16,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0"/>
             </text>
         </area>
         <area areatype="textarea">
@@ -248,7 +248,7 @@
                 <border applySpotColor="0" color="#ff000000" enabled="1" gap="10" position="outside" width="5"/>
             </decoration>
             <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'Calibri'; font-size:16pt; font-weight:400; font-style:normal;"><table style="-qt-table-type: root; margin-top:22px; margin-bottom:0px; margin-left:0px; margin-right:0px;"><tr><td style="border: none;"><p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000000;">kk centred single text over multiple lines with border gg</span></p></td></tr></table></body></html>]]><outline width="0"/>
-                <textFormat Alignment="ALIGNVCENTER,ALIGNHCENTER" IndentMargin="0" VerticalIndentMargin="50" backgroundColor="#00000000" font="Calibri,16,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0"/>
+                <textFormat Alignment="ALIGNHCENTER,ALIGNVCENTER" IndentMargin="0" VerticalIndentMargin="50" backgroundColor="#00000000" font="Calibri,16,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0"/>
             </text>
         </area>
         <area areatype="textarea">
@@ -266,7 +266,7 @@
                 <border applySpotColor="0" color="#ff000000" enabled="1" gap="10" position="outside" width="2"/>
             </decoration>
             <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'Calibri'; font-size:16pt; font-weight:400; font-style:normal;"><table style="-qt-table-type: root; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;"><tr><td style="border: none;"><p align="right" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:10pt; color:#000000;">A grey image, itself with a blue border, then with added red border to the image in Cewe editor</span></p></td></tr></table></body></html>]]><outline color="#ff000000" width="0"/>
-                <textFormat Alignment="ALIGNTRAILING" IndentMargin="0" VerticalIndentMargin="50" backgroundColor="#00000000" font="Calibri,16,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0"/>
+                <textFormat Alignment="ALIGNRIGHT" IndentMargin="0" VerticalIndentMargin="50" backgroundColor="#00000000" font="Calibri,16,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0"/>
             </text>
         </area>
         <area areatype="textarea">
@@ -275,7 +275,7 @@
                 <border applySpotColor="0" color="#ff000000" enabled="1" gap="10" position="outside" width="2"/>
             </decoration>
             <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'Calibri'; font-size:10pt; font-weight:400; font-style:normal;"><table style="-qt-table-type: root; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;"><tr><td style="border: none;"><p align="right" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000000;">A grey image, itself with a blue border, then with added red border to the image in Cewe editor</span></p></td></tr></table></body></html>]]><outline width="0"/>
-                <textFormat Alignment="ALIGNTRAILING,ALIGNABSOLUTE" IndentMargin="0" VerticalIndentMargin="50" backgroundColor="#00000000" font="Calibri,10,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0"/>
+                <textFormat Alignment="ALIGNRIGHT,ALIGNABSOLUTE" IndentMargin="0" VerticalIndentMargin="50" backgroundColor="#00000000" font="Calibri,10,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0"/>
             </text>
         </area>
     </page>
@@ -297,7 +297,7 @@
                 <shadow shadowAngle="135" shadowBlurNew="4" shadowDistance="10" shadowEnabled="1" shadowIntensity="51" shadowWidthInMM="1.5"/>
             </decoration>
             <image filename="safecontainer:/20200306_111748.jpg" useABK="1">
-                <cutout left="-0.00740574" scale="0.324043" top="0"/>
+                <cutout left="-0.00814632" scale="0.324043" top="0"/>
             </image>
         </area>
         <area areatype="clipartarea">
@@ -353,7 +353,7 @@
             <designElementIDs passepartout="125186"/>
             <decoration/>
             <image filename="safecontainer:/20200320_124632.jpg" passepartoutDesignElementId="125186" useABK="1">
-                <cutout left="-86.8283" scale="0.169986" top="0"/>
+                <cutout left="-86.8291" scale="0.169986" top="0"/>
             </image>
         </area>
         <area areatype="imagearea">
@@ -362,6 +362,18 @@
             <image filename="safecontainer:/20200320_124632.jpg" useABK="1">
                 <cutout left="0" scale="0.170387" top="-1.97917"/>
             </image>
+        </area>
+        <area areatype="clipartarea">
+            <position height="103.041" left="317.902" rotation="300" top="1946.44" width="241.463" zposition="111"/>
+            <designElementIDs clipart="121285"/>
+            <decoration/>
+            <clipart designElementId="121285">
+                <ClipartConfiguration applySpotColor="0" mirror="">
+                    <colors>
+                        <color source="#ffbd9641" target="#ff000000"/>
+                    </colors>
+                </ClipartConfiguration>
+            </clipart>
         </area>
         <area areatype="textarea">
             <position height="282" left="353.928" rotation="0" top="783.066" width="407.022" zposition="7000"/>
@@ -396,6 +408,13 @@
             <decoration/>
             <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'Calibri'; font-size:11pt; font-weight:400; font-style:normal;"><table style="-qt-table-type: root; margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000000;">White clipart in the back, down-loaded frame (passepartout) id 125186 on a snow picture. This shows that at least one instance of issue 55 now seems to work!</span></p><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000000;">https://github.com/bash0/cewe2pdf/issues/55</span></p></td></tr></table></body></html>]]><outline width="0"/>
                 <textFormat Alignment="ALIGNLEADING" IndentMargin="5" VerticalIndentMargin="5" backgroundColor="#00000000" font="Calibri,11,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0"/>
+            </text>
+        </area>
+        <area areatype="textarea">
+            <position height="282" left="169.13" rotation="0" top="1894.39" width="283.623" zposition="7006"/>
+            <decoration/>
+            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'Calibri'; font-size:16pt; font-weight:400; font-style:normal;"><table style="-qt-table-type: root; margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000000;">A recolored clipart arrow,</span></p><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000000;">id 121285</span></p></td></tr></table></body></html>]]><outline width="0"/>
+                <textFormat Alignment="ALIGNLEADING" IndentMargin="5" VerticalIndentMargin="50" backgroundColor="#00000000" font="Calibri,16,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0"/>
             </text>
         </area>
     </page>
@@ -533,19 +552,19 @@
     </page>
     <userfeedback></userfeedback>
     <fotoRelationships>
-        <foto id="safecontainer:/img6.png"/>
+        <foto id="safecontainer:/img3.png"/>
         <foto id="safecontainer:/img5.png"/>
-        <foto id="safecontainer:/img2.png"/>
+        <foto id="file:///D:/temp/20200320_124632.jpg">
+            <foto id="safecontainer:/20200320_124632.jpg" nature="RELATIONSHIP_ONE_TO_ONE_COPY"/>
+        </foto>
         <foto id="safecontainer:/img.png"/>
         <foto id="file:///D:/Users/pete/Pictures/PhotoAlbumWork/PhotoAlbum2020/Album Candidates/20200306_111748.jpg">
             <foto id="safecontainer:/20200306_111748.jpg" nature="RELATIONSHIP_ONE_TO_ONE_COPY"/>
         </foto>
+        <foto id="safecontainer:/img2.png"/>
         <foto id="safecontainer:/img4.png"/>
-        <foto id="file:///D:/temp/20200320_124632.jpg">
-            <foto id="safecontainer:/20200320_124632.jpg" nature="RELATIONSHIP_ONE_TO_ONE_COPY"/>
-        </foto>
+        <foto id="safecontainer:/img6.png"/>
         <foto id="safecontainer:/GreySquareBlueBorder.jpg"/>
-        <foto id="safecontainer:/img3.png"/>
     </fotoRelationships>
-    <statistics assistantUsed="0" countPauses="23" elapsedTimeGross="2020-04-26T19:39:51" elapsedTimeNet="187847" fotosAdded="8" fotosRemoved="4" pauseTime="146740" sessionsUsed="35"/>
+    <statistics assistantUsed="0" countPauses="24" elapsedTimeGross="2020-04-26T19:39:51" elapsedTimeNet="197014" fotosAdded="8" fotosRemoved="4" pauseTime="155480" sessionsUsed="36"/>
 </fotobook>

--- a/tests/unittest_fotobook.mcf.pdf
+++ b/tests/unittest_fotobook.mcf.pdf
@@ -2,8 +2,8 @@
 %“Œ‹ ReportLab Generated PDF document http://www.reportlab.com
 1 0 obj
 <<
-/F1 2 0 R /F10+0 100 0 R /F11+0 104 0 R /F12+0 108 0 R /F2+0 68 0 R /F3+0 72 0 R 
-  /F4+0 76 0 R /F5+0 80 0 R /F6+0 84 0 R /F7+0 88 0 R /F8+0 92 0 R /F9+0 96 0 R
+/F1 2 0 R /F10+0 102 0 R /F11+0 106 0 R /F12+0 110 0 R /F2+0 70 0 R /F3+0 74 0 R 
+  /F4+0 78 0 R /F5+0 82 0 R /F6+0 86 0 R /F7+0 90 0 R /F8+0 94 0 R /F9+0 98 0 R
 >>
 endobj
 2 0 obj
@@ -37,7 +37,7 @@ Gb"0W0oOgV(^Ao*SBds\5jGC:E+90L3_43%E8eg%ETtK)B#,W##2:;S,@GTRK>E2-d:u2*?&`arJVW1E
 endobj
 6 0 obj
 <<
-/Contents 112 0 R /MediaBox [ 0 0 608.0315 779.5276 ] /Parent 111 0 R /Resources <<
+/Contents 114 0 R /MediaBox [ 0 0 608.0315 779.5276 ] /Parent 113 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R /FormXob.ad9368b98cce2e1fdd4f78c4ae2491ce 5 0 R /FormXob.f35c4967eeb38278b329d670bee7be7e 4 0 R
 >>
@@ -65,7 +65,7 @@ Gb"0W]kZ>)(^Apb9nZJX^f=d#XmEpR,ZUk[(',4#N!ZK-VKLuESI;@Qb$D.nQ]PEBmJC#Z@h1*.3LVae
 endobj
 9 0 obj
 <<
-/Contents 113 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 111 0 R /Resources <<
+/Contents 115 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 113 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.00fff8af43475f74423436e21a951773 7 0 R /FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R /FormXob.2064d33219443e23da9a2d10abec1abc 8 0 R
 >>
@@ -101,7 +101,7 @@ Gb"0WZ&05u'F*KPp&u3I2E0C7;"+Y,fLIXb$&fWX&iNoe"MqlA9G^BU#rFNmW!+mpK6`&CQT]T_;Vp/6
 endobj
 13 0 obj
 <<
-/Contents 114 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 111 0 R /Resources <<
+/Contents 116 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 113 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R /FormXob.1bb58dfad9388feeb97ea3e7205e5327 10 0 R /FormXob.3b48f897f0cbd788f5d8a491ed8742b5 12 0 R /FormXob.5e09d7bc671cceb6907ba9cdd71b47e0 11 0 R
 >>
@@ -129,7 +129,7 @@ Gb"0W98_Lo(][raU>.%2nHjRCT>9c/ZANj\Chte3fFUaG$m>q0',um=nA_M>3TPqs+fa%gP$3nfbm,>&
 endobj
 16 0 obj
 <<
-/Contents 115 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 111 0 R /Resources <<
+/Contents 117 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 113 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R /FormXob.1bb58dfad9388feeb97ea3e7205e5327 10 0 R /FormXob.7daf57d829fc24ec630d6a2a7b051c7b 15 0 R /FormXob.aea9d506c329e5ecf66ff4f39f532fd7 14 0 R
 >>
@@ -141,7 +141,7 @@ endobj
 endobj
 17 0 obj
 <<
-/Contents 116 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 111 0 R /Resources <<
+/Contents 118 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 113 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R
 >>
@@ -161,7 +161,7 @@ s4IA0!"_al8O`[\!<<*#!!*'"s4[N@!!EB+"9S`/"9\i2"U"u6$O6n@"pYVF$4%"N%M99a%M0-`'H.`"
 endobj
 19 0 obj
 <<
-/Contents 117 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 111 0 R /Resources <<
+/Contents 119 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 113 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R /FormXob.fd94038f0ff945677983d82cc27a8122 18 0 R
 >>
@@ -357,35 +357,27 @@ s4IA0!"_al8O`[\!<<*#!!*'"s4[N@!!EB+"9S`/"9\i2"U"u6$O6n@"pYVF$4%"N%M99a%M0-`'H.`"
 endobj
 43 0 obj
 <<
-/Contents 118 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 111 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
-/FormXob.06a96263b269780d0543221a7556c288 22 0 R /FormXob.0d49f8a05ecb3b22cc45984fd8b923c0 40 0 R /FormXob.24695dee9f38aaafc0aadc936678f034 38 0 R /FormXob.2fe24235750cf1a7315cb40e1724c6d3 42 0 R /FormXob.315347ebea4617ebd2e670277d3b3ca2 28 0 R /FormXob.3c422b92ea04549738305e87f5acd811 20 0 R 
-  /FormXob.6c2bddcf74f9ce99a21343655ea2af70 21 0 R /FormXob.80c5ce2f238a281c775092c533cf58e1 26 0 R /FormXob.8e940e861f0128145fb20f4b2ab76dec 32 0 R /FormXob.a25ec7d2e6cce7c393fbfd7c041bf4be 30 0 R /FormXob.d5c2c5bc36755dca2cb32d0cde0e9c68 34 0 R /FormXob.e19e93b56b25e730b7e4a7dab6f89ffd 36 0 R 
-  /FormXob.fc5c21ada4e64b4feaa1447c4e61120a 24 0 R
+/BitsPerComponent 8 /ColorSpace /DeviceRGB /Filter [ /ASCII85Decode /FlateDecode ] /Height 61 /Length 42 /SMask 44 0 R 
+  /Subtype /Image /Type /XObject /Width 143
 >>
->> /Rotate 0 /Trans <<
-
->> 
-  /Type /Page
->>
+stream
+Gb"0;0`_7S!5bE%:MgImTE"rlzzzzz!!'MIAiThl~>endstream
 endobj
 44 0 obj
 <<
-/Contents 119 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 111 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
-/FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R
+/BitsPerComponent 8 /ColorSpace /DeviceGray /Decode [ 0 1 ] /Filter [ /ASCII85Decode /FlateDecode ] /Height 61 /Length 1309 
+  /Subtype /Image /Type /XObject /Width 143
 >>
->> /Rotate 0 /Trans <<
-
->> 
-  /Type /Page
->>
+stream
+Gb!$HHUq(4(r23$>#sX1XG85_V8kDbf*j.),s>O*@9At$).?s*]d_DSZPOoN.Jk>?`<om-_%M)cBkGbF0M/<VJ^mZ'1t6n)qp+$Qo%`Q.gHGQ8gV3-grc[_?kC2TM&0$5U[B!G_]]46<UJZq_>A+n#9@HTPD%-^(/,sEBCMA,LS-9kV/D;/4UY)GO"Dn`Y&%8J0Te-=^_)BhBBSuj@>JWclK=2%.CBU,]@+lfTU]tY(Qd?KK]ILapAL21*5Ze@OSa0sI!5nBt6^:2H"L-(b2Q*ZkRfLR_7U\qo"GlLLRmJLV,!]*4fXqpH('3PSJ;m/p>6GLe!Lp[:nS/p>&o8Hka("D."IlR1Z2C<efObq:&'R5Mi1t?>faGJ>ZI#P0>%5A1F/OpZ?0ogQ'9-jH&h[u`<Z8P0j`3Y4m2lcV%2JWD:@)(=?gM/9Rs@6WWl5$lD]PZOLN4ot,tQN"BC$,uZ5Sga(j@r>4aT<;YiGIm\kEaaVm.L!d\jj`4^f45j$t5>EaFippV#H.HIOIS"Um-A`\n(%>=6#@O8Mt23D=Pm;JmCkU.u%0FsI2;QaE12KqU8=[L%R#d/ladIWA`"7J.qhCsobOX5l%X7!F2Ii8c3tM8kGUK0pkn\*lPb./hZ4;6EZ$?u4$WN(]r=XlAjH@'MEqLR$>!=]Ei"@Ps(k3N5ks]89eLp*tK+LprA+^I]M[=^:fEddllNEEqDOc+V92W\WUI%dSn+*qn$lXI<HsDU/^TlN`^nWk:;H?dM;sd<N]Bp:>C=G;sZp7!Ioo<L6arRS/@N8s8tV_bfRk`CX;<WD)#U9-([)M(NO&]EO/mNq<uY<iY8)1G0V=3Xq&9Yb,E.Bmn;!k<Uj=Y<D=_K_#(EI82OHf?E*^)#TepCkK.dq?47NA0rOFUa:F#Ent'(kL4U;m3t\9-JJXja)Ks=b9,t+0"#\BjKqY*<%Aku@3:/7..sJ1F"'*ur&9YNp9_=?o$-H&Mn1N#&p'@SIJ>espW_q?+I/Ia&mU40+8pHR5uX%3"-i1>ap;IF;UmTfI*f`NS^@6V;M#$idktM.fr*ROeE[;eL")aj]uO!XN#*Q]bg=W!LE;,YkRA"[/`k"Xc$Z?lK9d1f*_`oo\;VdWLD8S1IP5-AkZWXLXV!\k+TE6]T3T5GjEq3QRTK%@1]4V'#!F3D<JN)lnVQ>M#;+O#eaEc0LT<Dc`o#I5HNE.o$JM:3j29Jr7`[3mK2i000F_J7O8jT4<l_4mcuIG.k/Er&ngeA)5mLh@2YHuV5e,W`5K4U(d+u+cZZ*8I5?rQ'SXQEE]SU=t$^;\i%f~>endstream
 endobj
 45 0 obj
 <<
-/Contents 120 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 111 0 R /Resources <<
+/Contents 120 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 113 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
-/FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R
+/FormXob.06a96263b269780d0543221a7556c288 22 0 R /FormXob.0d49f8a05ecb3b22cc45984fd8b923c0 40 0 R /FormXob.24695dee9f38aaafc0aadc936678f034 38 0 R /FormXob.2fe24235750cf1a7315cb40e1724c6d3 42 0 R /FormXob.315347ebea4617ebd2e670277d3b3ca2 28 0 R /FormXob.3c422b92ea04549738305e87f5acd811 20 0 R 
+  /FormXob.6c2bddcf74f9ce99a21343655ea2af70 21 0 R /FormXob.70824bf5c11a8a58473f33e8af7543ca 43 0 R /FormXob.80c5ce2f238a281c775092c533cf58e1 26 0 R /FormXob.8e940e861f0128145fb20f4b2ab76dec 32 0 R /FormXob.a25ec7d2e6cce7c393fbfd7c041bf4be 30 0 R /FormXob.d5c2c5bc36755dca2cb32d0cde0e9c68 34 0 R 
+  /FormXob.e19e93b56b25e730b7e4a7dab6f89ffd 36 0 R /FormXob.fc5c21ada4e64b4feaa1447c4e61120a 24 0 R
 >>
 >> /Rotate 0 /Trans <<
 
@@ -395,7 +387,7 @@ endobj
 endobj
 46 0 obj
 <<
-/Contents 121 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 111 0 R /Resources <<
+/Contents 121 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 113 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R
 >>
@@ -407,7 +399,7 @@ endobj
 endobj
 47 0 obj
 <<
-/Contents 122 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 111 0 R /Resources <<
+/Contents 122 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 113 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R
 >>
@@ -419,7 +411,7 @@ endobj
 endobj
 48 0 obj
 <<
-/Contents 123 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 111 0 R /Resources <<
+/Contents 123 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 113 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R
 >>
@@ -431,7 +423,7 @@ endobj
 endobj
 49 0 obj
 <<
-/Contents 124 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 111 0 R /Resources <<
+/Contents 124 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 113 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R
 >>
@@ -443,7 +435,7 @@ endobj
 endobj
 50 0 obj
 <<
-/Contents 125 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 111 0 R /Resources <<
+/Contents 125 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 113 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R
 >>
@@ -455,7 +447,7 @@ endobj
 endobj
 51 0 obj
 <<
-/Contents 126 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 111 0 R /Resources <<
+/Contents 126 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 113 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R
 >>
@@ -467,7 +459,7 @@ endobj
 endobj
 52 0 obj
 <<
-/Contents 127 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 111 0 R /Resources <<
+/Contents 127 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 113 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R
 >>
@@ -479,7 +471,7 @@ endobj
 endobj
 53 0 obj
 <<
-/Contents 128 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 111 0 R /Resources <<
+/Contents 128 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 113 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R
 >>
@@ -491,7 +483,7 @@ endobj
 endobj
 54 0 obj
 <<
-/Contents 129 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 111 0 R /Resources <<
+/Contents 129 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 113 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R
 >>
@@ -503,7 +495,7 @@ endobj
 endobj
 55 0 obj
 <<
-/Contents 130 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 111 0 R /Resources <<
+/Contents 130 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 113 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R
 >>
@@ -515,7 +507,7 @@ endobj
 endobj
 56 0 obj
 <<
-/Contents 131 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 111 0 R /Resources <<
+/Contents 131 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 113 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R
 >>
@@ -527,7 +519,7 @@ endobj
 endobj
 57 0 obj
 <<
-/Contents 132 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 111 0 R /Resources <<
+/Contents 132 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 113 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R
 >>
@@ -539,7 +531,7 @@ endobj
 endobj
 58 0 obj
 <<
-/Contents 133 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 111 0 R /Resources <<
+/Contents 133 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 113 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R
 >>
@@ -551,7 +543,7 @@ endobj
 endobj
 59 0 obj
 <<
-/Contents 134 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 111 0 R /Resources <<
+/Contents 134 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 113 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R
 >>
@@ -563,7 +555,7 @@ endobj
 endobj
 60 0 obj
 <<
-/Contents 135 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 111 0 R /Resources <<
+/Contents 135 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 113 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R
 >>
@@ -575,7 +567,7 @@ endobj
 endobj
 61 0 obj
 <<
-/Contents 136 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 111 0 R /Resources <<
+/Contents 136 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 113 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R
 >>
@@ -587,7 +579,7 @@ endobj
 endobj
 62 0 obj
 <<
-/Contents 137 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 111 0 R /Resources <<
+/Contents 137 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 113 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R
 >>
@@ -599,7 +591,7 @@ endobj
 endobj
 63 0 obj
 <<
-/Contents 138 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 111 0 R /Resources <<
+/Contents 138 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 113 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
 /FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R
 >>
@@ -611,9 +603,9 @@ endobj
 endobj
 64 0 obj
 <<
-/Contents 139 0 R /MediaBox [ 0 0 608.0315 779.5276 ] /Parent 111 0 R /Resources <<
+/Contents 139 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 113 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
-/FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R /FormXob.ad9368b98cce2e1fdd4f78c4ae2491ce 5 0 R /FormXob.f35c4967eeb38278b329d670bee7be7e 4 0 R
+/FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R
 >>
 >> /Rotate 0 /Trans <<
 
@@ -623,12 +615,36 @@ endobj
 endobj
 65 0 obj
 <<
+/Contents 140 0 R /MediaBox [ 0 0 581.1024 765.3543 ] /Parent 113 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
+/FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R
+>>
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+66 0 obj
+<<
+/Contents 141 0 R /MediaBox [ 0 0 608.0315 779.5276 ] /Parent 113 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
+/FormXob.1597d5c82ac78185f08b4a1e0a8181fd 3 0 R /FormXob.ad9368b98cce2e1fdd4f78c4ae2491ce 5 0 R /FormXob.f35c4967eeb38278b329d670bee7be7e 4 0 R
+>>
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+67 0 obj
+<<
 /Filter [ /FlateDecode ] /Length 705
 >>
 stream
 xœmÕÍja…ñ½W1Ë–.ôÿ€‰I ‹~ĞôÌ8¦q”Ñ,r÷õx¤¥¥Ê3¼3òsu¦ËÇ»Ç¡?6Óoã®}êÍ¦ÖcwØ½m×<w/ı0mÖ}{¼Ü¿Ûíj?™^~z?»íã°ÙMæófúıtx8ïÍ‡›óõi¹zíŸÇşãdúu\wc?¼üçèém¿í¶İplf“Å¢Yw›Ó^í¿¬¶]3ıûù?§?Ş÷]£ç{!®İ­»Ã~Õvãjxé&óÙlÑÌëa1é†õ?g¢W|çyÓş\—gg§kqjaZÙŠ6¶¡íè`:Ù‰.v¡¯ØWèkö5ú†}ƒ¾eß¢—ì%ú}‡¾gß£Ø§8ú~¡_àú~¡_àú~¡_àú~¡_àú~¡_àú~¡_àú~¡_àú~¡_àWú~¥_áWú~¥_áWú~¥_áWú~¥_áWú~¥_áWú~¥_áWú~¥_áWú~¥_á7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßàwú~§ßáwú~§ßáwú~§ßáwú~§ßáwú~§ßáwú~§ßáwú~§ßáwú~§ßáúş ?àúş ?àúş ?àúş ?àúş ?àúş ?àúş ?àúş ?àOúş¤?áOúş¤?áOúş¤?áOúş¤?áOúş¤?áOúş¤?áOúş¤?áOúş¤?á/úş¢¿à/úş¢¿à/úş¢¿à/úş¢¿à/úş¢¿à/úş¢¿à/úş¢¿à/úş¢ÿ²—%ÀV`Ş~Pû6§m:oàyx09ıĞıÉın·ğù¶œ™endstream
 endobj
-66 0 obj
+68 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 28338 /Length1 56152
 >>
@@ -724,16 +740,16 @@ S§Š¹‰˜:-}Ô(CºX2æ™’IÙÓM-ÅèœBS[ ›Ú*&ä”™:!®L¢HÍi1õ¨¸üÑbYÎS'‰œìy¦#2s.1u²lÎ¹ÑÔ)
 øğ$ğsà	àgÀãÀcÀ£ÀOG€Ÿ €ûû€{{€€»»€;;€Û°ØÜÜ
 ÜÜ 777 ×××× W?~\\	\\ü ¸¸¸¸¸¸ø>pğ=à»Àw€óó€oçç ggß¾	|8Ø+<{$Î¿Äù—8ÿç_âüKœ‰ó/qş%Î¿Äù—8ÿç_âüKœ‰ó/qş%Î¿Äù—! >@ÂHø 	 á$|€„ğ>@ÂHø 	 á$|€„ğ>@ÂHø 	 á$|€„ğ>@ÂHø 	 á$|€„ğç_âüKœ‰³/qö%Î¾ÄÙ—8ûg_âìKœ}‰³/qöÿÛ~økşÓşßÀ×üG„Ãq™ú™°u‹ø?vÉZMendstream
 endobj
-67 0 obj
+69 0 obj
 <<
-/Ascent 750 /CapHeight 631.8359 /Descent -250 /Flags 4 /FontBBox [ -502.9297 -312.5 1240.234 1026.367 ] /FontFile2 66 0 R 
+/Ascent 750 /CapHeight 631.8359 /Descent -250 /Flags 4 /FontBBox [ -502.9297 -312.5 1240.234 1026.367 ] /FontFile2 68 0 R 
   /FontName /AAAAAA+Calibri /ItalicAngle 0 /StemV 87 /Type /FontDescriptor
 >>
 endobj
-68 0 obj
+70 0 obj
 <<
-/BaseFont /AAAAAA+Calibri /FirstChar 0 /FontDescriptor 67 0 R /LastChar 127 /Name /F2+0 /Subtype /TrueType 
-  /ToUnicode 65 0 R /Type /Font /Widths [ 0 506.8359 506.8359 506.8359 506.8359 506.8359 506.8359 506.8359 506.8359 506.8359 
+/BaseFont /AAAAAA+Calibri /FirstChar 0 /FontDescriptor 69 0 R /LastChar 127 /Name /F2+0 /Subtype /TrueType 
+  /ToUnicode 67 0 R /Type /Font /Widths [ 0 506.8359 506.8359 506.8359 506.8359 506.8359 506.8359 506.8359 506.8359 506.8359 
   506.8359 506.8359 506.8359 0 506.8359 506.8359 506.8359 506.8359 506.8359 506.8359 
   506.8359 506.8359 506.8359 506.8359 506.8359 506.8359 506.8359 506.8359 506.8359 506.8359 
   506.8359 506.8359 226.0742 325.6836 400.8789 498.0469 506.8359 714.8438 682.1289 220.7031 
@@ -748,7 +764,7 @@ endobj
   433.1055 452.6367 395.0195 314.4531 460.4492 314.4531 498.0469 506.8359 ]
 >>
 endobj
-69 0 obj
+71 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 721
 >>
@@ -763,7 +779,7 @@ xœ…ÕÍjaÆñ}®b–ŠHz¾[ÚZé¢*ÖH'oë ™„iºèİ›'O©àBşÃ¼‡ùÍêÌ/®/¯ÇaßÍ¿NÛş¶í»ûa\Oíqû4õ
 ¿Ò¯ğ+ı
 ¿Ñoğı¿Ñoğı¿Ñoğı¿Ñoğı¿Ñoğı¿Ñoğı¿Ñoğı¿Ñoğı¿Óïğ;ı¿Óïğ;ı¿Óïğ;ı¿Óïğ;ı¿Óïğ;ı¿Óïğ;ı¿Óïğ;ı¿Óïğ;ıĞğıĞğıĞğıĞğıĞğıĞğıĞğıĞğıÒŸğ'ı	ÒŸğ'ı	ÒŸğ'ı	ÒŸğ'ı	ÒŸğ'ı	ÒŸğ'ı	ÒŸğ'ı	ÒŸğ'ı	Ñ_ğıÑ_ğıÑ_ğıÑ_ğıÑ_ğıÑ_ğıÑ_ğıÑ_ğı/âe`W`¾®£şiš›ê¸-‹+gÛëBİmw˜Âï7²f¬Úendstream
 endobj
-70 0 obj
+72 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 18518 /Length1 27168
 >>
@@ -826,16 +842,16 @@ wÛzÌ}Ò§ƒÏÿ. }º,(ibú4±kNcü•®Óß;¼kçıåï^|ìõmÏ3bÓƒİ#àÓèƒ,qš³½¡UHs˜ãÁÙPkZ ‹
 „gŸåoWª±2ÿóÚ>=³P‡ó?Á_ÇiPÉÇ«êÃ¿âêP/×'úcoTp>¬LĞ´6±+Å³ùLZ91*øº:Ã½|YŸysí%N¨äÍàºWmMŸ9äı¿Ğ•l-œ7Ï†©å?ÂTÉù½ê4ı'¨*ªÅ‰9f˜Flı‡Ãk_3ä]]BVÔ&¤B_*Œåe­\Î°Và½—ëF&ä˜!ŒU\™he¬«ßÂ?°œ5æŞrš*ç1ù`Øÿ©åÙR©å´\ú¿Ña 9Û†0äuË¯æ?›ë™«±Í,.çk¹>«!±gsTŸ€ñ×Ò¾ªÏÚÉã´mÅ'Qü·ÿËãıVòÕ^Ï×E^bæÿÎÂ`R½ÿ1hÎH‰úµ§q‰qÆ2jKpˆ1û–>­ÿÅYÀÚ5òµ`hÁŞÙ6òUf¼[™è¥:ñlHüÆ„t­å³ì+)z±ñk‰Ø+[NKé³KfŸÃÀß`ößa§‘?Wá;•	Ök[ã<=Î¯gPûëòßá¬W·­­ªş-îÏèÛşØ~ çí:¾2«şCï½¶êÿ7Üé½Š÷4‡ôZ—­	¨¯Eûëôş[¸ÎéÃl&Æ\Zùx½–n3_‹8ÿ0ùTÏåTÅœ©Á{gq•¡3WcVF¾¯Cz²6á%ıÔp½Ùø_y”Qè|nÙİ{ï
 ©M`™ñOMbÅ·&hûïWmİoø¯wİF¶ZÒ€a‡ÉäEXzf…÷õÕ-İûüW|êëÇUŸå­qí¬zœ‘˜&'ˆãÄsñ:ì¬˜Tº„krFfÏmé6G;´Î~zf³ÿ³æ·?ñÉI-¾}ş”ıÁ“ê1_×èÖ5&ÍoÀüüp~CÒ¼z_p^ıÒæä¶Z[zëlLmoJk›7ØÚ–4g.æçÌõçÌMš]‹ùÙµŞàìÚ¤êO°º¦½)yñ¨¤ŒE˜ò_ßûÉŞã{…½“Ò÷l8'ıí]Ùéoï|)}çÆ‰éù›6öK¿ckVúÖ…é[0m.+LßˆiÃŒºôõ˜ì¤+oÁÁ¥ç¤ïÆ´«½ }íúš+¦§w`Z9ÕœŞ>µ!}9¦ëñy)¦%˜*+Ìé³0å—]9,}Æ•IéS§K¿SE©9=~S9^ó¯,u¤OÁ”Îô`‘7Pèõx]C½˜×šïU†xåÁ^!ê%yŞƒ¹{ÿì{¿,GfØÊp¤¥Ûƒ)©¶@R²ÍëóÛ\nÍ¡9­V›İª¨«l2[Q² Ö(û+ìÓ¿×‰<ÇœînN†™ÓI±9}b:]È„É#;İ€÷ËGvÆ"öÀºIù‘	ÊÄ+§n¸y–vÒU{€LîWí¡xsš~åÔ=ÄªÛùx±— ,k¿)˜¸O›Ií¬špùÔÎªÔiù,³.uÛì´´FşÛÏöÒxé˜5£!ÂCÄ¸G o›ÖDaŸ‚_µèûÓès‹lSØ¬†L9¡Ó<	ÓÄ+;“Ã##ÿ=›nendstream
 endobj
-71 0 obj
+73 0 obj
 <<
-/Ascent 700.1953 /CapHeight 700.1953 /Descent -189.9414 /Flags 4 /FontBBox [ -215.332 -306.6406 1093.262 951.6602 ] /FontFile2 70 0 R 
+/Ascent 700.1953 /CapHeight 700.1953 /Descent -189.9414 /Flags 4 /FontBBox [ -215.332 -306.6406 1093.262 951.6602 ] /FontFile2 72 0 R 
   /FontName /AAAAAA+FranklinGothic-Medium /ItalicAngle 0 /StemV 87 /Type /FontDescriptor
 >>
 endobj
-72 0 obj
+74 0 obj
 <<
-/BaseFont /AAAAAA+FranklinGothic-Medium /FirstChar 0 /FontDescriptor 71 0 R /LastChar 127 /Name /F3+0 /Subtype /TrueType 
-  /ToUnicode 69 0 R /Type /Font /Widths [ 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+/BaseFont /AAAAAA+FranklinGothic-Medium /FirstChar 0 /FontDescriptor 73 0 R /LastChar 127 /Name /F3+0 /Subtype /TrueType 
+  /ToUnicode 71 0 R /Type /Font /Widths [ 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
   1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
   1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
   1000 1000 250 275.3906 378.418 586.4258 586.4258 771.4844 716.7969 213.8672 
@@ -850,7 +866,7 @@ endobj
   441.4063 441.8945 418.457 293.457 500 293.457 586.4258 1000 ]
 >>
 endobj
-73 0 obj
+75 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 715
 >>
@@ -858,7 +874,7 @@ stream
 xœ}ÕÍjaÅñ½W1Ë–.Ìó€ù„,’†$7`ô5ê(£¡äîëñ„
 í€òf^ü¹:ãËÛ«Û~µïÆÃfşÔöİrÕ/†¶Û¼óÖ½´×U?í«ùşãîø=_Ï¶£ñáğÓûnßÖ·ır3šLºñãáán?¼w_Î×·çÕºíîÛ¯ÇÍzÖ?<İ=¿‹6¬ú×ÿ¾ôô¶İşlëÖï»“ÑtÚ-Úòğƒw³íılİºñ¿Nşyïù}Û:=ŞéóÍ¢í¶³yfıkMNN¦İ¤n¦£Ö/şz&zÊ3/ËùÙğñîÉášZØ‚V¶¢mhg;:ØNv¢‹]èSö)úŒ}†>gŸ£/ØèKö%úŠ}…¾f_£oØ‡8ú~¡_àú~¡_àú~¡_àú~¡_àú~¡_àú~¡_àú~¡_àú~¡_àWú~¥_áWú~¥_áWú~¥_áWú~¥_áWú~¥_áWú~¥_áWú~¥_áWú~¥_á7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßàwú~§ßáwú~§ßáwú~§ßáwú~§ßáwú~§ßáwú~§ßáwú~§ßáwú~§ßáúş ?àúş ?àúş ?àúş ?àúş ?àúş ?àúş ?àúş ?àOúş¤?áOúş¤?áOúş¤?áOúş¤?áOúş¤?áOúş¤?áOúş¤?áOúş¤?á/úş¢¿à/úş¢¿à/úş¢¿à/úş¢¿à/úş¢¿à/úş¢¿à/úş¢¿à/úş¢ÿc!>– [ñûœ¢ùÛ0Vê¸ÇáÁä¬úö9¢ÛÍ§ğùB©§¾endstream
 endobj
-74 0 obj
+76 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 46978 /Length1 75168
 >>
@@ -1061,16 +1077,16 @@ kÕÜ1lÂ# oğÄ¡   ãAhïæhèC§pÎBh—Ê0ÿ+CË¹%å<ôáÉ¹æºşÀ:ğc£ G xàı$”
 Ú­_; •Û•”@ß’ ¨£™™"¿I©è°k5vë°«UvTßHÕLUû¦@‡ı1…½|5Ép ÔÈÉÿ‚ğ ?ø-€Œ|Âû ¾09|5_´F;P#UèI­|í|MCíªˆCb<´YŒƒ}bÜ¨µB<×Z§	a«NÉ³~àu€ø#€œ¯åkóq$I²ŠB·ğø§ÉªÅƒH(ÚN*YUE’âáPì‰}Èsé,&49C’IÖ±Ü$V›Á8ı
 ØSäßèbUìendstream
 endobj
-75 0 obj
+77 0 obj
 <<
-/Ascent 693.3594 /CapHeight 662.1094 /Descent -215.8203 /Flags 4 /FontBBox [ -568.3594 -306.6406 2045.898 1039.551 ] /FontFile2 74 0 R 
+/Ascent 693.3594 /CapHeight 662.1094 /Descent -215.8203 /Flags 4 /FontBBox [ -568.3594 -306.6406 2045.898 1039.551 ] /FontFile2 76 0 R 
   /FontName /AAAAAA+TimesNewRomanPSMT /ItalicAngle 0 /StemV 87 /Type /FontDescriptor
 >>
 endobj
-76 0 obj
+78 0 obj
 <<
-/BaseFont /AAAAAA+TimesNewRomanPSMT /FirstChar 0 /FontDescriptor 75 0 R /LastChar 127 /Name /F4+0 /Subtype /TrueType 
-  /ToUnicode 73 0 R /Type /Font /Widths [ 777.832 777.832 777.832 777.832 777.832 777.832 777.832 777.832 777.832 777.832 
+/BaseFont /AAAAAA+TimesNewRomanPSMT /FirstChar 0 /FontDescriptor 77 0 R /LastChar 127 /Name /F4+0 /Subtype /TrueType 
+  /ToUnicode 75 0 R /Type /Font /Widths [ 777.832 777.832 777.832 777.832 777.832 777.832 777.832 777.832 777.832 777.832 
   777.832 777.832 777.832 777.832 777.832 777.832 777.832 777.832 777.832 777.832 
   777.832 777.832 777.832 777.832 777.832 777.832 777.832 777.832 777.832 777.832 
   777.832 777.832 250 333.0078 408.2031 500 500 833.0078 777.832 180.1758 
@@ -1085,7 +1101,7 @@ endobj
   500 500 443.8477 479.9805 200.1953 479.9805 541.0156 777.832 ]
 >>
 endobj
-77 0 obj
+79 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 712
 >>
@@ -1101,7 +1117,7 @@ xœuÕÍja…ñ½W1Ë–Rôÿ€1EÚÒäŒ©gd4‹Ü}=I¡´Ê3Ì¼øsuÆ×÷7÷İæĞŒıò±=4ëM·Ú}ÿ6,Ûæ
 ¿Ò¯ğ+ı
 ¿Ò¯ğı¿Ñoğı¿Ñoğı¿Ñoğı¿Ñoğı¿Ñoğı¿Ñoğı¿Ñoğı¿Ñoğ;ı¿Óïğ;ı¿Óïğ;ı¿Óïğ;ı¿Óïğ;ı¿Óïğ;ı¿Óïğ;ı¿Óïğ;ı¿ÓïğıĞğıĞğıĞğıĞğıĞğıĞğıĞğıĞğ'ı	ÒŸğ'ı	ÒŸğ'ı	ÒŸğ'ı	ÒŸğ'ı	ÒŸğ'ı	ÒŸğ'ı	ÒŸğ'ı	ÒŸğıÑ_ğıÑ_ğıÑ_ğıÑ_ğıÑ_ğıÑ_ğıÑ_ğıÑ^ˆó`+0x3´|†ãBVñ4<˜œM×~ç®ßá>¿Ó¹¢uendstream
 endobj
-78 0 obj
+80 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 20601 /Length1 31928
 >>
@@ -1184,16 +1200,16 @@ _m)¾ó¨´:g ””#nV½ÜõN«áÛ¼~°ó/æ:R¤8G?e8ã+U›ãX¬L¾ÎŸgd²Ü9{hü\(oˆ-î}ÿ ˆ(<ª	âR
 •…óöÌ=~’ÆõMò°:ú´9û”ñ}jùß%·ù÷ö>Áw8<^±}¥òãò—å¯Êß–·–Ö¯}¹öÕÚ·k[Cålùrùvù~yëıŸˆÓSªDÿËjª­#›Ù)EñWÙ3¡jKı¬İ½‡µİ;©}¸‡=?dt±İ%è5CÛRzØ%…Š«Å.éb¶x¹x»x¿ø¸HA]äÜE&-Ö^ñk…¥ÒÛâŸ?zYzDGk~ÔÒ­7‡ˆ¨ùãÖP4ö‰¿…‚Ÿ†ÃÑĞ§â“ÏÄØg­Lyèóöè“/ÄØÛÛ¢¼EÖt2t0Olk£öC31uŞ:ıÃr—t~½¢J×îÜ]oúº,İ]a2VFÏÍ],*7·m'Şş÷AáÍå]ÒeUZ.D¥kKªô›¥¨t`©°GºRP¥_şR	*ôô€Bçğ¤j‹Ş;ú¯İ+  Ü¸°pàÀÀU€+ €K #÷ŞôK+où¥ß| ı; ·¦üÒ2À€kÓ~i	à*Àx. \H(~i`ä­~éM€éI¿4 œ÷Kï Œ\€Û$@÷¡ğh8|0Ü~ ÜŒ„›‡Ã/…›ÃB$Ü?|¹¯u_oğ¥½­?úqğ‡{ZåİÁ]R«ó—»§éÏ
 ¿ëhîŞÙÓ²£ë-áÎï·´w¼Øµ-­æmÛc½¾ç4ù¶qK`0˜>6…‚b÷+~)xÄ/5ú%á°_:³_,µÇ…øÄx©C„öÜxi_|İ/œ-ôÅKÍg.L¯Šâog [Úr}]&J¾ëë[ i?úóÓëb/ÑWÅ®úÄuñòÒ­[İ•ŞÌL_OIŸ›.e{fJ#Ø¹İ3CŸF°­¾Ê+×W÷ùgøg°Ã_B=qßj3Z«÷s½ìŠZ»Z‹®ÊË²l[ş¥Ãàendstream
 endobj
-79 0 obj
+81 0 obj
 <<
-/Ascent 664.0625 /CapHeight 664.0625 /Descent -256.8359 /Flags 262148 /FontBBox [ -158.2031 -256.8359 1005.859 916.9922 ] /FontFile2 78 0 R 
+/Ascent 664.0625 /CapHeight 664.0625 /Descent -256.8359 /Flags 262148 /FontBBox [ -158.2031 -256.8359 1005.859 916.9922 ] /FontFile2 80 0 R 
   /FontName /AAAAAA+BodoniMT-Bold /ItalicAngle 0 /StemV 165 /Type /FontDescriptor
 >>
 endobj
-80 0 obj
+82 0 obj
 <<
-/BaseFont /AAAAAA+BodoniMT-Bold /FirstChar 0 /FontDescriptor 79 0 R /LastChar 127 /Name /F5+0 /Subtype /TrueType 
-  /ToUnicode 77 0 R /Type /Font /Widths [ 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+/BaseFont /AAAAAA+BodoniMT-Bold /FirstChar 0 /FontDescriptor 81 0 R /LastChar 127 /Name /F5+0 /Subtype /TrueType 
+  /ToUnicode 79 0 R /Type /Font /Widths [ 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
   1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
   1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
   1000 1000 245.1172 270.9961 555.1758 667.9688 490.2344 926.7578 759.7656 277.832 
@@ -1208,7 +1224,7 @@ endobj
   490.2344 490.2344 426.7578 394.043 565.918 394.043 666.9922 1000 ]
 >>
 endobj
-81 0 obj
+83 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 705
 >>
@@ -1216,7 +1232,7 @@ stream
 xœmÕÍjaÅñ½W1Ë–.ôùN@„|BiK“0ã˜
 uF³Èİ×ã‘Bå?¼¾òsu¦7·ıæĞL»ö©;4ëM¿»ıîml»æ¥{İôÑfµiç§Óg»]“éñòÓûşĞmúõn2Ÿ7Ó_ÇÃıa|o¾\^ß®w«]¿y|ş:™şWİ¸é_ÿwöô6ºm×šÙd±hVİúøóËáûrÛ5ÓOş?¿]£§g¡¯İ­ºı°l»qÙ¿v“ùl¶hæu¿˜tıêÓ™èï¼¬ÛßËñüİÙñµ8¶°­lEÛĞÎvt°ìD»Ğìô%û}Å¾B_³¯Ñ7ìô-û}Ç¾Cß³ÿp.ôüB¿À/ôüB¿À/ôüB¿À/ôüB¿À/ôüB¿À/ôüB¿À/ôüB¿À/ôüB¿À¯ô+üJ¿Â¯ô+üJ¿Â¯ô+üJ¿Â¯ô+üJ¿Â¯ô+üJ¿Â¯ô+üJ¿Â¯ô+üJ¿Â¯ô+üJ¿ÂoôüF¿ÁoôüF¿ÁoôüF¿ÁoôüF¿ÁoôüF¿ÁoôüF¿ÁoôüF¿ÁoôüF¿Áïô;üN¿Ãïô;üN¿Ãïô;üN¿Ãïô;üN¿Ãïô;üN¿Ãïô;üN¿Ãïô;üN¿Ãïô;üN¿ÃôüAÀôüAÀôüAÀôüAÀôüAÀôüAÀôüAÀôüAÀŸô'üIÂŸô'üIÂŸô'üIÂŸô'üIÂŸô'üIÂŸô'üIÂŸô'üIÂŸô'üIÂ_ôüEÁ_ôüEÁ_ôüEÁ_ôüEÁ_ôüEÁ_ôüEÁ_ôüEÁ_ôüEÿy!ÎK€­ÀÂ},Pû6Çq:Íàix09›¾ûXÊa7àŞÏÅkendstream
 endobj
-82 0 obj
+84 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 21861 /Length1 32952
 >>
@@ -1304,16 +1320,16 @@ GüÿÜ6ÿû«–ÿºŸüO:faÍ¶‹Õ}0Fó~
 œZÑORjÛ—T§»İ»Ø_JIÁ)s±fõ6õÁmAµvÛÁ­ù4Î/!9^/Ñ
 ^¯¢ä3ã¶ô9û½^Õ®¶)huJ«VhË,·‹…Ô6]İíjA7¤®'Ôån(¼	…uP0¹Ûÿ"qÒendstream
 endobj
-83 0 obj
+85 0 obj
 <<
-/Ascent 662.1094 /CapHeight 662.1094 /Descent -258.7891 /Flags 4 /FontBBox [ -101.0742 -277.832 1005.859 916.9922 ] /FontFile2 82 0 R 
+/Ascent 662.1094 /CapHeight 662.1094 /Descent -258.7891 /Flags 4 /FontBBox [ -101.0742 -277.832 1005.859 916.9922 ] /FontFile2 84 0 R 
   /FontName /AAAAAA+BodoniMT /ItalicAngle 0 /StemV 87 /Type /FontDescriptor
 >>
 endobj
-84 0 obj
+86 0 obj
 <<
-/BaseFont /AAAAAA+BodoniMT /FirstChar 0 /FontDescriptor 83 0 R /LastChar 127 /Name /F6+0 /Subtype /TrueType 
-  /ToUnicode 81 0 R /Type /Font /Widths [ 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+/BaseFont /AAAAAA+BodoniMT /FirstChar 0 /FontDescriptor 85 0 R /LastChar 127 /Name /F6+0 /Subtype /TrueType 
+  /ToUnicode 83 0 R /Type /Font /Widths [ 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
   1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
   1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
   1000 1000 245.1172 270.9961 408.2031 667.9688 490.2344 926.7578 708.0078 180.1758 
@@ -1328,7 +1344,7 @@ endobj
   541.9922 541.9922 426.7578 479.9805 526.8555 479.9805 666.9922 1000 ]
 >>
 endobj
-85 0 obj
+87 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 712
 >>
@@ -1344,7 +1360,7 @@ xœuÕËjÛP…á¹ŸBÃ–œ}OÀr…Ò†&/àÈrjˆe!;ƒ¼}½¼L
 ¿Ò¯ğ+ı
 ¿Ñoğı¿Ñoğı¿Ñoğı¿Ñoğı¿Ñoğı¿Ñoğı¿Ñoğı¿Ñoğı¿Óïğ;ı¿Óïğ;ı¿Óïğ;ı¿Óïğ;ı¿Óïğ;ı¿Óïğ;ı¿Óïğ;ı¿Óïğ;ıĞğıĞğıĞğıĞğıĞğıĞğıĞğıĞğıÒŸğ'ı	ÒŸğ'ı	ÒŸğ'ı	ÒŸğ'ı	ÒŸğ'ı	ÒŸğ'ı	ÒŸğ'ı	ÒŸğ'ı	Ñ_ğıÑ_ğıÑ_ğıÑ_ğıÑ_ğıÑ_ğıÑ_ğıÑ_ğı§	qš˜˜yŸs¨}ÇÃˆ:ÆãàÁÈY÷İçì¶Náş¡Y¤‹endstream
 endobj
-86 0 obj
+88 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 19324 /Length1 25400
 >>
@@ -1417,16 +1433,16 @@ sÿ›
 ó â¹)Gç«°Šhƒ
 kaŒnj‘bÁş°èÄ€?î·ˆ’¸.ÄG†$±9ŠDıñ`$\)k–,YT)®öF#±H_üIòòPHŒûâ11*Å¤è.)P¹Şò÷Jâ†Şhp(.®ëh—ú‡CşèÓÑOãR4†yŠ5•ê4-MzŠóŒŒ‰~,­?‹KQ) Æ£ş€´Óİ!Fúş[¦ë@‚Ğa<…ùÑ`@(N„í0‚~ Ÿˆúd9"HÁŞd1ÍˆEf>KT8*‘r]jãKğÄQ©¤B/rE°¼ô!ï³R/‡Ş"Æ³º -¦`¬¶†»Ğ çzLB×«ÔfƒRBsŒ+%2Kö¦Vx¢Ïå~½S);¦Ö“ÉW	¨~"İã©ç8âAE.¿*[¿‚Ç•R$¥'âJËÛ©H°ãXëıŸ>á äïĞ²8üûZŞMXÛ•¸ZñÊ	ô—b/ ÆæÁıí¢>8	¼yxàÍÃahƒ71dÿ-`	t¹¸òå€²Á&œçsqNpë™ı\e¯b0Ğ û¢©šÈ o½Vl…]®‚<¯¯´ï.`vÑş·Ÿ‰endstream
 endobj
-87 0 obj
+89 0 obj
 <<
-/Ascent 494.6289 /CapHeight 494.6289 /Descent -244.1406 /Flags 68 /FontBBox [ -291.9922 -242.1875 1045.898 916.9922 ] /FontFile2 86 0 R 
+/Ascent 494.6289 /CapHeight 494.6289 /Descent -244.1406 /Flags 68 /FontBBox [ -291.9922 -242.1875 1045.898 916.9922 ] /FontFile2 88 0 R 
   /FontName /AAAAAA+PalaceScriptMT /ItalicAngle -41 /StemV 87 /Type /FontDescriptor
 >>
 endobj
-88 0 obj
+90 0 obj
 <<
-/BaseFont /AAAAAA+PalaceScriptMT /FirstChar 0 /FontDescriptor 87 0 R /LastChar 127 /Name /F7+0 /Subtype /TrueType 
-  /ToUnicode 85 0 R /Type /Font /Widths [ 500 500 500 500 500 500 500 500 500 500 
+/BaseFont /AAAAAA+PalaceScriptMT /FirstChar 0 /FontDescriptor 89 0 R /LastChar 127 /Name /F7+0 /Subtype /TrueType 
+  /ToUnicode 87 0 R /Type /Font /Widths [ 500 500 500 500 500 500 500 500 500 500 
   500 500 500 500 500 500 500 500 500 500 
   500 500 500 500 500 500 500 500 500 500 
   500 500 156.25 161.1328 208.0078 426.7578 312.9883 375 323.2422 125 
@@ -1441,14 +1457,14 @@ endobj
   312.9883 323.2422 210.9375 365.2344 490.2344 365.2344 426.7578 500 ]
 >>
 endobj
-89 0 obj
+91 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 720
 >>
 stream
 xœ…ÕËjÛP…á¹ŸBÃ–Rì}OÀâ\Àƒ´¥É8²œbÙÈÎ o_/¯B¡T ñƒ¾3ÚãëÅÍ¢ß›ña×>tÇf½éWCwØ½m×<uÏ›~$Ú¬6íñıíül·Ëıh|Úüğv8vÛE¿Ş¦ÓfüóôñpŞšOWçëË|·Úõ›ûÇ¯óİËjq\¾lÚÏ£ñ÷aÕ›şù?Ë^÷û—nÛõÇf2šÍšU·>ıô~¹ÿ¶ÜvÍøß{ÿ¬||Ûwß…hw«î°_¶İ°ìŸ»Ñt2™5Óº›º~õ×7ÑîyZ·¿–ÃûÚÉéšZØ‚V¶¢mhg;:ØNv¢‹]èöú’}‰¾b_¡çì9úš}¾aß oÙ·è;öé„S¡_àú~¡_àú~¡_àú~¡_àú~¡_àú~¡_àú~¡_àú~¡_àú~¥_áWú~¥_áWú~¥_áWú~¥_áWú~¥_áWú~¥_áWú~¥_áWú~¥_áWú~£ßà7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßà7ú~§ßáwú~§ßáwú~§ßáwú~§ßáwú~§ßáwú~§ßáwú~§ßáwú~§ßáwúş ?àúş ?àúş ?àúş ?àúş ?àúş ?àúş ?àúş ?àúş¤?áOúş¤?áOúş¤?áOúş¤?áOúş¤?áOúş¤?áOúş¤?áOúş¤?áOúş¢¿à/úş¢¿à/úş¢¿à/úş¢¿à/úş¢¿à/úş¢¿à/úş¢¿à/úş¢¿à/úß'Äû$À¬ÀüFíë0œæÔyNFÎ¦ï>Fé~·Ç.Ü¿6¶©wendstream
 endobj
-90 0 obj
+92 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 24965 /Length1 38608
 >>
@@ -1539,16 +1555,16 @@ Sócêœ_µŞùŠeé+§ï«Ò]ô½%û.²Y6Å_0£Tü>ŒßÄWğŸ±Ûq5q_Â"İ¬¹w¤çÜ‘>öŞsËeäÄMÚQ¥ª,
 ’“¦×-­ªIZ
 WİÊ‘ÔLü%PfVsxÈZ:"É¤ƒÄ†£HÊ¡ªC2Tu)”ŒªløB&Í¡jÔsUWŒç¢‘YsG’ùLÎ¬B••^S7{§[š¤Ê)DË2«ÑùQendstream
 endobj
-91 0 obj
+93 0 obj
 <<
-/Ascent 666.9922 /CapHeight 666.9922 /Descent -255.8594 /Flags 262212 /FontBBox [ -145.9961 -282.2266 1044.922 916.9922 ] /FontFile2 90 0 R 
+/Ascent 666.9922 /CapHeight 666.9922 /Descent -255.8594 /Flags 262212 /FontBBox [ -145.9961 -282.2266 1044.922 916.9922 ] /FontFile2 92 0 R 
   /FontName /AAAAAA+BodoniMT-BoldItalic /ItalicAngle -12 /StemV 165 /Type /FontDescriptor
 >>
 endobj
-92 0 obj
+94 0 obj
 <<
-/BaseFont /AAAAAA+BodoniMT-BoldItalic /FirstChar 0 /FontDescriptor 91 0 R /LastChar 127 /Name /F8+0 /Subtype /TrueType 
-  /ToUnicode 89 0 R /Type /Font /Widths [ 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+/BaseFont /AAAAAA+BodoniMT-BoldItalic /FirstChar 0 /FontDescriptor 93 0 R /LastChar 127 /Name /F8+0 /Subtype /TrueType 
+  /ToUnicode 91 0 R /Type /Font /Widths [ 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
   1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
   1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
   1000 1000 245.1172 323.2422 555.1758 667.9688 490.2344 926.7578 759.7656 280.7617 
@@ -1563,7 +1579,7 @@ endobj
   541.9922 541.9922 490.2344 394.043 565.918 394.043 666.9922 1000 ]
 >>
 endobj
-93 0 obj
+95 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 713
 >>
@@ -1571,7 +1587,7 @@ stream
 xœ}ÕÍja…ñ½W1Ë–Rôÿ€ùiK“0ã˜
 q”Ñ,r÷õx$…R: <ÃÌ‹?Wg|3¿÷ëC3ş1lÛÇîĞ¬ÖırèöÛ·¡íšçîeİD›åº=œïNßíf±‡ß÷‡n3ïWÛÑtÚŒîÃ{óéêt}¹Ş.·ıúáéëü°x]·ŸGãïÃ²ÖıË^y|Ûí^»M×šÉh6k–İêøc‹İ·Å¦kÆÿ>÷ç­§÷]×èé^ˆn·Ën¿[´İ°è_ºÑt2™5ÓºŸº~ù×3Ñy^µ¿ÃùİÉñš[Ø‚V¶¢mhg;:ØNv¢‹]èöú’}‰¾b_¡¯Ù×èöú–}‹¾cß¡ïÙÇ8ú~¡_àú~¡_àú~¡_àú~¡_àú~¡_àú~¡_àú~¡_àú~¡_àWú~¥_áWú~¥_áWú~¥_áWú~¥_áWú~¥_áWú~¥_áWú~¥_áWú~¥_á7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßàwú~§ßáwú~§ßáwú~§ßáwú~§ßáwú~§ßáwú~§ßáwú~§ßáwú~§ßáúş ?àúş ?àúş ?àúş ?àúş ?àúş ?àúş ?àúş ?àOúş¤?áOúş¤?áOúş¤?áOúş¤?áOúş¤?áOúş¤?áOúş¤?áOúş¤?á/úş¢¿à/úş¢¿à/úş¢¿à/úş¢¿à/úş¢¿à/úş¢¿à/úş¢¿à/úş¢ÿ¼ç%ÀV`ö>†¨}†ãF¶ñ4<˜œuß}Ìçn»Ã)|~şÆ¤ôendstream
 endobj
-94 0 obj
+96 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 26966 /Length1 41176
 >>
@@ -1668,16 +1684,16 @@ B–Ú8K±e{G“	.¡Ä„	ç6÷ºÑd²ñÜéL4r.	êÊçâd¯•ìgœ£Äã.Ló6Q&Hé>GğÅÉ‘ƒjBdó
 v/tú‡!0›Î¾x–:sŸLÉM¯}õÅWÙß}ÀGŞa"'ŞË¾Çïşè]æÔß›#läâ¯1y›í×}«í‰¹>ı„Ş”L=N“ÆMú¢ÛÂq!)ãß~¡=ò…{Ú#{ãÑ{˜ÈÅClä+‡¸Èá»¸È¡»ØÈ]PèÛğ¨£ûøÈí·q‘Ûöq‘Ô>±$¹H9ÿ´åªäş>r"„ßÓ;²w„q×Ú56[Âf®¶	q›nM]eãc66jC•¶âC¸D(‹Ê#BQÀ^ŸAô	^ÖŒ&Z£ÕñJ•å:„]”İÃ2nìÑ;”.½Íh×›9«|{“ğ„ğ†0)ğQ—7”5„Š‚Ebƒ·Áİàh°5˜„ußÀ6 †–8Îš—¡e­MY†ëµMÙxdÙiV\Y–U·lXw
 ã»×Cl–9x£Ö,wğ4óÂë7¬;$ù÷3c”]¶ù»ÖŸbPSÌ®]G.©kÖeÅƒ§¨uİ)7­_¿>[»¬eÁZñdÛ—Ú^Ïúìó¬GË²õ×dİ¦Èìƒäw ?êT¸xq¶lq[¶|ñæEù	x`pffD2’ÿX*c€Ş,\ç^‰dÙJh:yM¤ô\ä{r<¥&´iYİ´,«Z¡eCÖ€›ïÁMÜèM@½à´¯Î*”¤¸î›N)QÓ)\µ¨ÉO!T`<µõBKægS‹QvÁâ¬6’Õ@&m 	56:"Æ¼3ZçØØÇë²<Ä+MëAüĞW(endstream
 endobj
-95 0 obj
+97 0 obj
 <<
-/Ascent 666.9922 /CapHeight 666.9922 /Descent -250.9766 /Flags 68 /FontBBox [ -187.9883 -262.207 1069.824 916.9922 ] /FontFile2 94 0 R 
+/Ascent 666.9922 /CapHeight 666.9922 /Descent -250.9766 /Flags 68 /FontBBox [ -187.9883 -262.207 1069.824 916.9922 ] /FontFile2 96 0 R 
   /FontName /AAAAAA+BodoniMT-Italic /ItalicAngle -12 /StemV 87 /Type /FontDescriptor
 >>
 endobj
-96 0 obj
+98 0 obj
 <<
-/BaseFont /AAAAAA+BodoniMT-Italic /FirstChar 0 /FontDescriptor 95 0 R /LastChar 127 /Name /F9+0 /Subtype /TrueType 
-  /ToUnicode 93 0 R /Type /Font /Widths [ 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+/BaseFont /AAAAAA+BodoniMT-Italic /FirstChar 0 /FontDescriptor 97 0 R /LastChar 127 /Name /F9+0 /Subtype /TrueType 
+  /ToUnicode 95 0 R /Type /Font /Widths [ 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
   1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
   1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
   1000 1000 245.1172 323.2422 419.9219 667.9688 490.2344 926.7578 812.9883 213.8672 
@@ -1692,14 +1708,14 @@ endobj
   490.2344 437.9883 375 479.9805 526.8555 479.9805 666.9922 1000 ]
 >>
 endobj
-97 0 obj
+99 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 716
 >>
 stream
 xœ}ÕÍjaÅñ½W1Ë–.Ìó€ù„,Ò–$7`œ7©GÍ"w_'¤Ph”ÿ0óâÏÕ™^Ş^İ«}7ı9n–mß=¯†~l»ÍÛ¸lİS{YÑ®_-÷wÇïåz±L‡Şwû¶¾7“Ù¬›Şîöã{÷åüx};W‹×ûÍÛĞ·şîñbóÚLŒ}WÃËÿßzxÛn_Ûºûîd2Ÿw}{>üäİbû}±nİôŸGÿ¼øø¾mï…úå¦o»íbÙÆÅğÒ&³““y7«›ù¤ı_ÏDOyæéyùk1~¼{r¸æ‡¶ •­hcÚÙv “èbú”}Š>cŸ¡ÏÙçèöú’}‰¾b_¡¯Ù×èöáÎ„~_èø…~_èø…~_èø…~_èø…~_èø…~_èø…~_èø…~_èø•~…_éWø•~…_éWø•~…_éWø•~…_éWø•~…_éWø•~…_éWø•~…_éWø•~…_éWø~ƒßè7ø~ƒßè7ø~ƒßè7ø~ƒßè7ø~ƒßè7ø~ƒßè7ø~ƒßè7ø~ƒßè7ø~‡ßéwø~‡ßéwø~‡ßéwø~‡ßéwø~‡ßéwø~‡ßéwø~‡ßéwø~‡ßéwøƒş€?èøƒş€?èøƒş€?èøƒş€?èøƒş€?èøƒş€?èøƒş€?èøƒş€?èø“ş„?éOø“ş„?éOø“ş„?éOø“ş„?éOø“ş„?éOø“ş„?éOø“ş„?éOø“ş„?éOø‹ş‚¿è/ø‹ş‚¿è/ø‹ş‚¿è/ø‹ş‚¿è/ø‹ş‚¿è/ø‹ş‚¿è/ø‹ş‚¿è/ø‹ş‚¿èÿXˆ%ÀV`ÿ>·hù6‡™:äqx09«¡}îèv³Å)|~¿©endstream
 endobj
-98 0 obj
+100 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 13302 /Length1 18456
 >>
@@ -1750,16 +1766,16 @@ O%¥=ãoPfj
 Ú‚?D½Ä54Ç 9ÔÔy!¦Ñè¯…ïó„)¡?Óp¬…c«áXÇ18:áğ³ı§Ñac3ûıÔ-¸†*xÏ#''y¢epœæEÑ)ê:Î¢A ã4<wú0÷ØëçÑQ¸~î÷2}Ùoæù(ZÍCHÆ<Ã›FnÁ4Ò@5\ÓóôH|eh†o9¼œB7?^Â@_úìeh…ï|wço~íx~/¡G3„şæJ áÓ¤ mp}7ÌsL?ÏİTäse±÷¢ÈÉŸF&JœĞNo D¨Ş¾ÈÏÎAüëDSÕ]"ê‰ß7H¹†ü5%¢T'µ‰:M}ÆËçíãüFşeA¦ [ğZœ+n]ÜSq?»!Ìî•‹ö‰>oŒ?ÿ[q¶ø^ñÏÅŸKJ%$O%$%ô&\L¸‘8’ø«¤pÒ¤KeÒ1éÈRdİ²}²K²_Ëf“’ÍÉ§“é”PÊÅT”J}1-%-”v2í}yœ|“üGéIé+Ó_T Å˜âG‹2UÊ”#Ê§2E™Å™»2Ÿ‰ég?Z‡¨Q }bÄG) S¢	8cË/øıİÓ£ùÿ pœqmöÅÚ$\¯‰µ)h÷ÆÚ<ym¬ÍG2´-Ö .tÂÉ¾ıl›ÇüV}Ê¶ùÌuL±ms'±í8¶­bÛÒbs¬‘²U®M p½k“pı¹X›‚öbmJ'd±6åºX[€$Bl[ÄĞ@"¶Ï¼—³m1{=“m'°íB¶Ä¼—´±ídhËH?ÛNaûDØv*;N?ÛNc¯±mûìV¶­dû`ÛYlŸãl;‡mŸeÛylÿ'Ù¶miÇq4¿Æ¶¹ñÅ´ÅÜõ÷Ù6Gÿ'Ñ±Éu+–¯W=®²”•YUÅª¦Ñ5£ë'Ç†T‘É±ÑåëÆ†'U#ë•ëVŒ¨Â£k‡UM•td0<´|bd`İ¿¼÷//F‡Ö¯]£²í¶Cì~SäÖ#çT‘uƒC«Ö­R.û2‚Të†–¯_?´_±Fµ~xHÕŞ¦jX¯ÊWEšŒkUC#ãC‡¡‡…Ğ(èúj4€F µMb	B+Ñô·îµ¡õğ½Âç:ğÇÉ'Èïß…ãiòò"
 @ß14	÷V åhz«ĞãpXPü³B«&èÅŒºzÁ{T(Â¶Fá™u0ò<9	WG Ç 2¢Jv<æı*†^,Cp0cEàÓWGà<W—Ãı–¾ÿısÿûQ¸ºCo††3#²Ãç­î|yú_½åË5Ã-Óo5Kï*¸6Š–ı?KH×¾W ]ëYú8ÊW°®‡¾Ìí0{*ÔO3³’ÏÙÔsó©‚>#ğüÚÈögÆ¸S/nµ™³ÿòŞoîè7cÜ®1¬Î|É˜#Ğgòös*›²PTå†Ï²;Ş°Æı²QBğ¹•*#?FâëØÙ`¨øògşu;öÿÎÜ´2ÿÍ?ÿùZ}Ñr^™ÃAÙm6Êj6S&ƒ‘*VQ9*^NB%Ià!ÛåS¼¯yˆ:|„wøîêÀÎ}Ô];ywuLQÑÚ‡$L~'àÇñë Ï\%wg¥¡ºŒt¯>öw«¥ÏH‡÷şPâ®}endstream
 endobj
-99 0 obj
+101 0 obj
 <<
-/Ascent 728.0273 /CapHeight 728.0273 /Descent -209.9609 /Flags 4 /FontBBox [ -173.8281 -210.9375 1185.059 946.2891 ] /FontFile2 98 0 R 
+/Ascent 728.0273 /CapHeight 728.0273 /Descent -209.9609 /Flags 4 /FontBBox [ -173.8281 -210.9375 1185.059 946.2891 ] /FontFile2 100 0 R 
   /FontName /AAAAAA+ArialRoundedMTBold /ItalicAngle 0 /StemV 87 /Type /FontDescriptor
 >>
 endobj
-100 0 obj
+102 0 obj
 <<
-/BaseFont /AAAAAA+ArialRoundedMTBold /FirstChar 0 /FontDescriptor 99 0 R /LastChar 127 /Name /F10+0 /Subtype /TrueType 
-  /ToUnicode 97 0 R /Type /Font /Widths [ 500 500 500 500 500 500 500 500 500 500 
+/BaseFont /AAAAAA+ArialRoundedMTBold /FirstChar 0 /FontDescriptor 101 0 R /LastChar 127 /Name /F10+0 /Subtype /TrueType 
+  /ToUnicode 99 0 R /Type /Font /Widths [ 500 500 500 500 500 500 500 500 500 500 
   500 500 500 500 500 500 500 500 500 500 
   500 500 500 500 500 500 500 500 500 500 
   500 500 250 333.0078 479.0039 551.7578 594.2383 854.0039 759.7656 240.2344 
@@ -1774,7 +1790,7 @@ endobj
   520.9961 541.9922 520.9961 384.7656 280.7617 384.7656 583.0078 500 ]
 >>
 endobj
-101 0 obj
+103 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 745
 >>
@@ -1790,7 +1806,7 @@ xœuÕËjÛP…á¹ŸBÃ–œ}W r+dĞuû }’bÙ(Î o_/­ĞBi¿Ğ9è#íùõİÍİ°=vó¯ã~½lÇîa;lÆö¼×
 ¿Ò¯ğ+ı
 ¿Ò¯ğı¿Ñoğı¿Ñoğı¿Ñoğı¿Ñoğı¿Ñoğı¿Ñoğı¿Ñoğı¿Ñoğ;ı¿Óïğ;ı¿Óïğ;ı¿Óïğ;ı¿Óïğ;ı¿Óïğ;ı¿Óïğ;ı¿Óïğ;ı¿ÓïğıĞğıĞğıĞğıĞğıĞğıĞğıĞğıĞğ'ı	ÒŸğ'ı	ÒŸğ'ı	ÒŸğ'ı	ÒŸğ'ı	ÒŸğ'ı	ÒŸğ'ı	ÒŸğ'ı	ÒŸğıÑ_ğıÑ_ğıÑ_ğıÑ_ğıÑ_ğıÑ_ğıÑ_ğıÑ_ğ÷ğßÊäïeêé{ÕëÔÓ;ØÓ‰çöğkNï`Sãÿ:Mš·‰‚™ƒÁù{œ­_Æñ4é¦é:0Œ®íĞ~àÃş€]øı“±Ñendstream
 endobj
-102 0 obj
+104 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 18218 /Length1 30008
 >>
@@ -1858,16 +1874,16 @@ S
 kÙØq5‡p,é^ç>4DáŠºu÷ñûÂõäõ¯IÎ!•‡Æ ŠpÎğ°ÛWzÛÎá|šÁ'z}£¾·[Zy¸{ù¤pfy]?ÚµàÊgÂÚò“ ÷õ;„ÕòuÔ|ı”Â½IkAùh. £èu½Î“‡u~ğüoƒêV É¾q´öo? »‚Àü?Óv…‹È?sÛ^!xUuiEX]©j\8Î¯ÂE\è}¥{S6r/C2²qãjJì¸ÕãBH½ å@
 @Ê‚”	I‰ƒÄBÂâ°úz©¾½şûú¿Õ_­ÿ¶şrıÅú?ÖRÿQı{õgêß¨­ştı«õ§êOÖ¿R¢şXıú½õÏ×oªßXß\¿¡¾©~mıêúUõ+ë'×WÕ¬7ÖÿÔ¸å3æøÿKaPGendstream
 endobj
-103 0 obj
+105 0 obj
 <<
-/Ascent 728.0273 /CapHeight 700.1953 /Descent -210.4492 /Flags 4 /FontBBox [ -513.1836 -789.0625 1961.426 1499.023 ] /FontFile2 102 0 R 
+/Ascent 728.0273 /CapHeight 700.1953 /Descent -210.4492 /Flags 4 /FontBBox [ -513.1836 -789.0625 1961.426 1499.023 ] /FontFile2 104 0 R 
   /FontName /AAAAAA+SegoeUISymbol /ItalicAngle 0 /StemV 87 /Type /FontDescriptor
 >>
 endobj
-104 0 obj
+106 0 obj
 <<
-/BaseFont /AAAAAA+SegoeUISymbol /FirstChar 0 /FontDescriptor 103 0 R /LastChar 133 /Name /F11+0 /Subtype /TrueType 
-  /ToUnicode 101 0 R /Type /Font /Widths [ 645.5078 645.5078 645.5078 645.5078 645.5078 645.5078 645.5078 645.5078 645.5078 645.5078 
+/BaseFont /AAAAAA+SegoeUISymbol /FirstChar 0 /FontDescriptor 105 0 R /LastChar 133 /Name /F11+0 /Subtype /TrueType 
+  /ToUnicode 103 0 R /Type /Font /Widths [ 645.5078 645.5078 645.5078 645.5078 645.5078 645.5078 645.5078 645.5078 645.5078 645.5078 
   645.5078 645.5078 861.3281 0 645.5078 645.5078 645.5078 645.5078 645.5078 645.5078 
   645.5078 645.5078 645.5078 645.5078 645.5078 645.5078 645.5078 645.5078 645.5078 645.5078 
   645.5078 645.5078 273.9258 284.1797 392.0898 590.8203 539.0625 818.3594 800.293 229.9805 
@@ -1883,14 +1899,14 @@ endobj
   1225.098 890.1367 1000 684.5703 ]
 >>
 endobj
-105 0 obj
+107 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 717
 >>
 stream
 xœuÕ]kÚpÅñ{_E.7ÆĞßs"´µBaO¬{6F+Ì(Ñ^ôİÏã)Œ- |Cò'Ÿ»3¾{˜?ôÛS3ş6ìÛÇîÔ¬·ıjèû—¡íš§n³íG¢ÍjÛŞî.ÿínyÏ‡_§n÷Ğ¯÷£é´??<†×æİÍåú°xéÛÓvßü´İ<ŸŞÆ_‡U7lûÍÿßx|9~v»®?5“ÑlÖ¬ºõùSŸ—‡/Ë]×ŒÿyìÏK?^]£—{¡¸İ¯ºãaÙvÃ²ßt£éd2k¦W“Ù¨ëW=½æ™§uû¼ŞŞœ¯Ù¹…-he+ÚØ†v¶£ƒèd'ºØ…¾b_¡¯Ù×èöú–}‹¾cß¡çì9ú}^°çú~¡_àú~¡_àú~¡_àú~¡_àú~¡_àú~¡_àú~¡_àú~¡_àWú~¥_áWú~¥_áWú~¥_áWú~¥_áWú~¥_áWú~¥_áWú~¥_áWú~¥_á7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßàwú~§ßáwú~§ßáwú~§ßáwú~§ßáwú~§ßáwú~§ßáwú~§ßáwú~§ßáúş ?àúş ?àúş ?àúş ?àúş ?àúş ?àúş ?àúş ?àOúş¤?áOúş¤?áOúş¤?áOúş¤?áOúş¤?áOúş¤?áOúş¤?áOúş¤?á/úş¢¿à/úş¢¿à/úş¢¿à/úş¢¿à/úş¢¿à/úş¢¿à/úş¢¿à/úş¢¿à¿¢¾¸¬ÅÛ*`7°¿7©}†ó\]Fò2B˜ŸmßıŞÑÃş€Søı”ê§endstream
 endobj
-106 0 obj
+108 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 13224 /Length1 23916
 >>
@@ -1947,16 +1963,16 @@ E5bn}å±OÌ™R$àşzö§Õ/ÉŞş{œ|£–l˜E«ğgFPœñ¡Afò0¿‚æ£Ÿ 5XVÂ¶®¿›ı9
 ¸¶úù6râ#p¾©™7‘ÿlÿ	¶?=ş¯ô™?„£tÚjÔ|‹‹Ñ/£·ñ˜«ŠŠ¥ŠßR\Pº•ÊG”O+w(ßàvq%ÕCê1õ›šZ«¶K÷…†g~¤\ÿ)ıúo6*Œ›ošnjm:Øô7fƒùïx'Ÿåáwñûù¿ŒBÙ²U|ÕªµYm=¶£¶Ó#Å¤¥Ò' ùD:ç¥”>´Ÿo.9^p.uşÈÕåîwÿ©ûGŞÓãñ"ï«¾gı¡Àgƒ;‚oË-r¼U~C>*ÿ]¨-TıÇĞ?‡Rd­A§‘­†<øÓ’L±¿Ú?]½…¿ô-bWÓÕsì}¾zÎBM=ÕsÅ4J°÷£Õs`Ì*çjFo=÷vıM@³jÃ
 ”Ö¢ÕsŒŒ€éÊ9ƒ´ØQ=gQ+–«çŠ;h”¨	VÏ9ÔŒŸ©«Ñr¼½z®½£ş& ™íÛ°qâ…ñuc/º‡7¬}ñÁ5Ï<õ=Û²æ…§ÜÅõ¿<à^óÜ“îñ7¹Ÿâ©ç6mxaSáW{âÅñÏ-"?Kµ$“É<ùRt¾v=No¬xê…MPp§î¾ü¿ı7ıêC`ğ&Ğh­CcèEäFÃpm-œ=l}=÷n_Û×^€kn†õÀ‚8[ƒCOÂqîo‚ã³pöĞ<¥@½	Ğ¯@é	¸?WC‹n=-…ZP’şËWÛ±	Îî¥ßñ‹´E›ªwÜPÃÏ£şÅ÷Å}ÇÓÈ×ÉßÜòİğş•PÆ,Å‡dL±}ıÊn©£Ç”¿ıéê÷Éê5tÿFí6sàÓÏ,¢gìgj·«XU´„*ŸŠFÿ8,àÓendstream
 endobj
-107 0 obj
+109 0 obj
 <<
-/Ascent 729 /CapHeight 667 /Descent -239 /Flags 4 /FontBBox [ -147 -250 1018 896 ] /FontFile2 106 0 R 
+/Ascent 729 /CapHeight 667 /Descent -239 /Flags 4 /FontBBox [ -147 -250 1018 896 ] /FontFile2 108 0 R 
   /FontName /AAAAAA+Function-Light /ItalicAngle 0 /StemV 71 /Type /FontDescriptor
 >>
 endobj
-108 0 obj
+110 0 obj
 <<
-/BaseFont /AAAAAA+Function-Light /FirstChar 0 /FontDescriptor 107 0 R /LastChar 128 /Name /F12+0 /Subtype /TrueType 
-  /ToUnicode 105 0 R /Type /Font /Widths [ 250 250 250 250 250 250 250 250 250 250 
+/BaseFont /AAAAAA+Function-Light /FirstChar 0 /FontDescriptor 109 0 R /LastChar 128 /Name /F12+0 /Subtype /TrueType 
+  /ToUnicode 107 0 R /Type /Font /Widths [ 250 250 250 250 250 250 250 250 250 250 
   250 250 250 250 250 250 250 250 250 250 
   250 250 250 250 250 250 250 250 250 250 
   250 250 250 259 360 600 547 605 629 245 
@@ -1971,86 +1987,72 @@ endobj
   401 428 453 240 500 240 667 250 492 ]
 >>
 endobj
-109 0 obj
-<<
-/PageMode /UseNone /Pages 111 0 R /Type /Catalog
->>
-endobj
-110 0 obj
-<<
-/Author (anonymous) /CreationDate (D:20210204104113-01'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20210204104113-01'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
-  /Subject (unspecified) /Title (untitled) /Trapped /False
->>
-endobj
 111 0 obj
 <<
-/Count 28 /Kids [ 6 0 R 9 0 R 13 0 R 16 0 R 17 0 R 19 0 R 43 0 R 44 0 R 45 0 R 46 0 R 
-  47 0 R 48 0 R 49 0 R 50 0 R 51 0 R 52 0 R 53 0 R 54 0 R 55 0 R 56 0 R 
-  57 0 R 58 0 R 59 0 R 60 0 R 61 0 R 62 0 R 63 0 R 64 0 R ] /Type /Pages
+/PageMode /UseNone /Pages 113 0 R /Type /Catalog
 >>
 endobj
 112 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20210215134637-01'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20210215134637-01'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+113 0 obj
+<<
+/Count 28 /Kids [ 6 0 R 9 0 R 13 0 R 16 0 R 17 0 R 19 0 R 45 0 R 46 0 R 47 0 R 48 0 R 
+  49 0 R 50 0 R 51 0 R 52 0 R 53 0 R 54 0 R 55 0 R 56 0 R 57 0 R 58 0 R 
+  59 0 R 60 0 R 61 0 R 62 0 R 63 0 R 64 0 R 65 0 R 66 0 R ] /Type /Pages
+>>
+endobj
+114 0 obj
 <<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 602
 >>
 stream
 GatU/a_olf%))NgGYD>#6>E?W9p=gn>_;h!X))PY[pBu6e*esWaTPbD"c?E47>VZ7j!.!C12-X<4hsJmk?A#9;!rk8Z;=lF<E\)mUrb.ZAj%&!<)*Z/)iq)IOB_/ikM("A^Q"L&(IR4teu9-QlupI89p@BSMKTG6Nl=^YpZNQkSI1/]L8,+4n.P)rn=#S]p419)/$74@BgUoKd'0dnM?rkgm%&.(NBZE.):j?hULW<d<]PpbL\qk@4&Qhc;F-$-l.81u-5t31jLWVt9:h.!"g2^bg.&*76#T/!$:\7Hc:K^e"87@S)c=KZR^Y%*HEVd&rR:L-W^RF%,UGnFV0r+[*XcYI]k]U^:?+%Ggs02S"6C%Ah_%@2O`B;&f-N;cYN]EHR,F3e\10prBnb)eMM(skNkBOria<dX_T6EM8mFoUa!;bP^*%_+-`1DQ'#pLQo=j,.H"p4f)n8Gph"Kcm`VttmWTqo.-Ws]O+no^I.HXXZm`,>dcbqi3]E"B"aI^a5CJZo575&Bm1;WleKWfUMWtj91j4#t[RNGJ[[D0_a(&Lr+SVCS+rB.!\?&UF^]%a,8pFdFPg>^Hra#COmE@Ced=]P0m~>endstream
 endobj
-113 0 obj
+115 0 obj
 <<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 779
 >>
 stream
 Gatm7a_olf%))NgGjGJ^,"4(I2Hq!YP/;u\2.J^fl_X-]8O'u^D!@`/2aD-ZL."mdO*i4)QA+Z)Z3<54iT(UP$1\Fb'gmER(O:%f+?EDrmFp)PX,LVrI@$I/p-\_R?RW:L0C1Gj>l&ue<]Vck@]?,mYU\SD:TbAdU/IkR[/sq\/"Nr9@bi=GKCZ*Xm:BBm<,Wp+RjmAT6Af)"m=RWRf".l]&1][*D<72-Y]1stbUe'Y%\ZgX+<P3W)G)L$UON:lmC4j)0Om!eR3H7*$Ij&m/hnuE:V[,Y8-fIa,qN9S@.3R+A:hXJ7N#j`[OulS4kq<W'(1H@'d.E`2L6m/YSJj\Cfg*U^Fb3Rl4o9>cV_B1r%$iH-9\PD*PkCj.4LaU"XI&b##W_glDB.3^)X/MIt5*LHPdiNB^2a*.JUNuNp-M&[S;+8#^XH"fhL0]`R6S=7:;n'cR`0reeoRl<M85aZ5F`?fq]rK;tsi>a$!P`,70kQper%h%ID#bKa"S]&8t^aCKG"+'X<?+:1H*2D(iSb_HC-_72*:EPf%e5au0ae+PggP;:MY\HSiqlOckZXN"aI!gf<VFa31>%l=(t.4uQ.6]l.Z=Iu*j(lR(r<0fJ^3q,@hg<j=+.B>h4#\W!=t<\(A+HRc-FL#dc\D3<5l.Ee4V_VeC4R`1F+_VPWH?MD0)\*<jtZBGW^`K!lCpuY-+[PUl[=g3H`_Li:hDJk3KkPF=agiGIET:oYpo"r5UJAP15X0NY9&L4,G?>:]HlXf6!:+25%!q+iogA~>endstream
 endobj
-114 0 obj
+116 0 obj
 <<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 374
 >>
 stream
 GatUm4`8.k%#&ntJen\[8tnkZ7@U8L!=rJ<+)aHlhLDKj,XC1n&0OLfq7]@VJ]?\tY?-7@)9s$&%PY*%#ntPOn2='L'6=X#8G6$-Jl,Ene4o,LmJHa*/'-`(Ufpm#)Omg=,q[nd))kk@]\]NHM'#\O7])7i>/73X2Q[FbNe-Za3^PQV!%0MA9KBs=qPZ44,J"So[P#h"g"Ldmm7Ze,4ElWJO6BM]6BT[Z&Al@(mqcE"9bd<.QtUT;1:"kR.ZHJi6;l87><7&Y;R:DG]jrKBMq?OE9@?RZ2S,sM"A!f"^knY\B4Q?4c_@2T0lBY[5H\He[[QMS[58mkO_.7,m`dSB,"G_Lh#):0.ACP/3(>kAp5agi#O_>:eG~>endstream
 endobj
-115 0 obj
+117 0 obj
 <<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 345
 >>
 stream
 GatVW4)+mQ$inY':>lS^erhRWC.#:,R_TVO4oTQHP2*g.B,1Q42AcilT-kLDS-P+ehEuNj_tA`b.BFb%JeZf1n?srV$XtHU-qC:L!LC[_,)1W1dS[baDiaAak@4T.f-]%H<&HKMdC*#Ya"h!]>'PHH*t/)5C]mn+p*RDJ%YXbeAr&7jDE6dFVoh2'6Tgjm-ItY#c=WjGc*\AU3f!.?Uh:?@JMQNGOs$3j-V\2\'%;u^-9u)T`&.LGA.F/S-_3+B](FuV@]iD]V:Uk$(hp48$'4eHhHOrfCW$LMSc;&m.mpZ]q5BO(boBq?<-4%M<OXc4iTsr))D4Ddl>kfkq#QOnG$4~>endstream
 endobj
-116 0 obj
+118 0 obj
 <<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 2031
 >>
 stream
 Gb"/)9on$e&A@sBn5QnHb]&<o5g_sI,aY/mZ3F5!k1u:9[qe(q3bT'&nJt6-<`WagoYsY7.1E:$CEBICGsf<>(7:a*P^fm&N'3T7a3T;;ZK[m1iegH;Z=hY6LCo&&N^B)0en?\DOu7.Lq"]6Br,$l(6$ms\Y8kijX95B`_Hj/Z'OjO50Y_3aY=Gcc:sY$AE!$H8p7<5`AJj`#F*dshE@HTQ%_7\P<O]MY.(*U@.kd!(lbYO6]H++HTN$pU"3&&r__q[f5GC/nE"a@(bIqmr1[lB"A.5k%0<p7:aMH<BBnQ9?`0:UBZ4h&O9*W3g@r05D-pO31PVE#d/52J;QGN@:n(I=D2SOFFQu=@u<nh(^rU<b]216/Oql1(LV\(kPqf>.F"oVH<HsY-+XuF=_/`,B6>dE\g%:.eqVmDl3j^pg@$1:H1%,oQ0_'HXRA1V<:!d*3DYXVg!WN]oeVK1bGTkgFtJes@oG]XljGh!+lBnFqp)#mM3]k(c6.MGdRR(Q\*$MJ"Y]j?D;ZL>j]+fIZ:4E4236DZ\gj4h(l6A[`OL3E`omK-;D*)GHD2V5&&pL64Rce!9(`1VsaP/a_6Sp\ou'NT=;:dWm1a,\WW>saOe=Rk,2X3KZ&2UQ0%SCicJG?Ft`_X>#U/K;ZW8W%9-Z!>ZdAl@$rn.8r0cgC%]9ghq-E%anE<kqX7Gpb!P+V,QGVSO+IJ\`;FSHNY<[t*4pnWTH'79..Y=f$[hiLQ(Eb4taSEF%H*YXVbb$ZHrIE>bX(dceZI-ruTNPb7I*Rs0d-4`Wn4RVd6@B=5"K'TPumi%,i[*%X(9_%GYfDDt)1SW`6l\WPZ]03t,[_)5oKGqql0^Z24#5'Q_=-s@#H_D\VcMsf@*=D"ZIC63#<c*@P:bd(RO,Z:h,AOFWn4lZWHJo^+P\FE`h9eSgP$U0t$6-23bC,BW1P]W1J-K-%OXjCMfjt"%jNIcB#Yh(Q%AdpiiZ8GCe^0qgb@.EQeq$r^r-pE+JqS=c'*f<L)mU%oZe_?g!>e]*m;\'K7o2ao3b!e.pnu=id81tRF<"DKYh.Fs^@%,hcJ=R2B<!`,3W.ukZ'RaCnPEP'n8?5t(7cV:IXJGO5-[S)ef)V7n3")lOQ`A_+qIUhDr,@DVXtHuOgBCk]&C2'_YH4ST7=b$G;7,Z_*s3*7f[[r[&$i=l"W$1PW7<_K_pebW[TcV/9s)DX^W5)S5#E;bF0lOOhXrPZjY^?hd"@($q=J"fWiTk[%<m+QGXAGIh`bM_?6#tf3VD@%kJ,Lr%PWhCYKk+k^,Bt]@7,HPP[VIh@[pkZSRS+#s0mjpb=E;'#I9A$ZY[-YN7)7O@<B%*h5u4`AhaKEj=pA-nBU8UjgWuV*dHbp[$_"R7^<2YW\N0P5)d.$U2DS<jKe1kWcsa0GN[))T!#R&V,=?-'WamYb8%:UgAqBhXY#9nJqao"eo`4g03e#YWB:tf%;GANBObC@:8iBJ7'mVYe[lafS,<1grKqet]<G4_.-`#H"k5]P:)jr\dU*SCp=42QrqcF=(dNqA\M2iojgmuS,b:+sXGFp5bY^(BJh:)J(9-U9GKMNUArhO@F)_mf[pcZC-2l:Y7Y1Qf5()^E*IX")Y*T=Hc7X#Kb'ZMpPsOjP%lNfQkEo"8Q-8*%)IY86jAJM/!cji4[F<.dDVKSh@KO[X`Ho:\Z`!,YO3:N1lb])(BQnLJV2$kU5*p;?\Rk7FF3`/;"_jmc)5QSpQ-q!G]&3N;6LT9kIWi%L:.W#]%?'1i^_e!><!jBN8Q_rPTMglMS.F%2Tm,o>Yqb%JMPX)%Pc\Bb9,uW6#BWi]Rjh_g]X^1$d!N`-oY;Xp7UrrqLlEKR**0?7'<jb?)hge(C^_*nZ;Fjpa[X`6/7kUGLmB'+O`_?jVIlU5Da;ST0!*Y'**&%;`9c;nUPO:UokN2/U/t_j):Y]@U53X3+1/0[1^a.B"8su!RL@4!h>qWnE67in"YOL`r!WurFG=V31ZXjS!B5+TI.+!!4[W6qCTPII:,M'*)]ONCUON;5_UEu~>endstream
 endobj
-117 0 obj
+119 0 obj
 <<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 2327
 >>
 stream
 Gb"/(962%@&AII3bUk#,j*<kL"C_^q.Os(MESr$D.qKAc$^-HYIQ_&a5.nMaQ0mKLGfV2cRd'7.l2Ki2mZh;a5;N2Og+rBuP+A.:-5F-t0kn.+QTq]5Q]p;S;EDd^YY!>+bI'3rc"rJH$>#D"jQsP3Dgs2O>h\D.p+!$:Pn,Y&Pm@aRQ^O6$P?]]m2oXkF6rp?]-+Pp#@n!IbG$tbO3mXo>Q'Bd'BPlERB^RTKM`Yf"A3*AeQ4^"28uu(@=Qb)@H5Y5_Q1A$^WUA3r_.g/h?kt;K9j5Va*jI:e![:A-f9=oU,'c^ZrkW8bT[C6[;SRlp04.atADcGG^09s&D^UDID4GV4B!P(MZoki@fp52_\CS[WNG[<:&eaS7d2<^Jl'C+lagWjO(^$*p'q'ntY1BoI*R0Sk:,2tUaQR(nh`=!YOXiK"$sY2.&r(0$On6MXOE&Bl/W&_]h(dZj0A,B5`e-3N1+m#I3gPZPIC;h5NN)0CoGOfKXj*]od0<dH9BdH,bFR$Yj0'6NYtV1<q-m4SS$J_Pl[>)dCAS8W3GHPF1W]eY.IDX1']#B5;]a#>"GAKoZmDSVm?ZiT.M5pg^;sp#?YB7+m4N?JgD^J5GFoGCrpD89BT!k=o?F/dhRF^e?dJ=6Go.>Hgmpa\2hrLdmlTK.;ujB4M5VP>CQQnk%nfJo$GfF>)mh1f+P-rBH5=N9*D!!h2V1-/,;=OO/;me?43e<D/W.fYOr,oP)i2D\q/O-jY>1Q(\2.A[j[Ha9e*GgFgMcXgpMN+a5)p#CSVQ1k!%C&:eGE,^<+N@j+aU-b7&5f#T7MbMB)a\78re.F,+:_(&QP<IDBA(]mW7qqH%c33keBYU1SkL]/lF=p.#<S#4XQ&b8#8_c,U+=Hcu";t($"*n9u;4)Ti)K%<(T0j2Igj$o#!P4bW[*6%8BpCAlIJq9=D?AF10`FG9<86o$KF?S#sp:2q!5<:@1dHd+Xuua\.a#S!ZEKPn=V'\KdN+)l^X/]sOAtS9+KYgT^j+X1I4pD\[b0jH/?pI)F#gLU"pP0WfCEo[2?bjGg#Y=N-g5F47Z^crB0N0U^?)M(+mL1!J$X3^m2*UYc(U-s^_9T<ZqijGd)a\ljsT:o_YEV=G1'2@@7HP/%LWn9l3/D6u5'duW<dm@RP5B$XaD:fg.\j\VAufY7W44-U/F"`C=(14rPundq6#82rItodS"i-)R,J$Za2"fWpEO?"E<bn(>VH(.?-pMjiMaYk"ti#eVJ?WfmbWMnWS`</q)7cM9HVS!2.EP8^94>]`n^9"53SN7''`g6TN?LX+!3*@p_4>8=b[k7HUDNNPW`L1pt0&K5S?[sc'CMc2gD4N`K'K*'9UG5.tXac/Jfs&+9D9;\MH?I1sOjLDABS!L1^"l3@#%5Og#s$;:4S$@-4gs#IrjdpQeDTlXH56BG#.V/AeH1[t@Th:(bK'PtSH&n#Y!gA0@rj^;+q$ubW*tHm?1DWBGDmETm*Y,mI'Qj(<qQOnt"YS7MjpaKDd=&0V-rm4aSTu2Yd=\0WRAMP2^e%!!>Op%l\[kT1+$Qp0Cj/:1:Fsh0o&Dg?./#&"fQu@-=4bk#>Z#.-1oC9upJ)qH4UnR%^9=o!d9;fgTK+8`,_-N+8oq&GF[-ZC^n$5SR^"apS(Tu%HdXLV0p<WNC<`"Q\2[I*@f(;/cj2Ud)E/4,@Dj)u_Pua5<u)-^,p^0R>keg)DS=0[EXe?bUq6ieBo6cMgtV/>1&n@%k`AOJkdHXJ)1<J/5$3T03!'3F.HR<3d8,.g="A%YUr`F4cD-Me&hA:YI=bO]pS6Qc[3Y10ksQA)8kuZ_BTC7ILN9_^StVJ_!BL/:SX\l>1T=4I_eIGAe?S@fQr>`.s-]\drKq(*BAe>N5ELGKTF?c#;FG"Z+TmqBFHu]d1U%HR&D5-A)4cT.:d=uWaZe(`_C`#)KAGmPZt3a?%Lr>jr7`SVlILPee4*[A@.T"49:6W@$pKdo8h40qbK$5k^!CS!^7DI6="HQWZH]C[,O3LUmq<(pYu-13MP_\$]daV!atK)h7:O8WY1>uQD?Vb6`JaubPRA,T^<UUOQ7_]<Z+o<sa!lPp]"RD9n'JkGa"WK#*Y4N*?^aUc,RJW[K$>b@MM!>$6uKEAG@MXWXCqDakt/AF`_:P*Q[kSB'n)^l,:1G1<uPabD",s4,A&]aGWPYc:XZ2jpKmf8S4'O-GY7Q]9U]Vs=@!954">%P-d<h`@8XD])Em^`OUAnOS>gf'o[%W5b5muupr(Zblbg?2q@gYS65:)#>'\81rbee>SpL)Oa)n.^EapH.V%XuT'$C8gB\PrW#FkVp5"/u-~>endstream
 endobj
-118 0 obj
-<<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1816
->>
-stream
-Gau0CgQ!4A&:O:S1_3+rLjQb6n%96p+<`?E=Fu=@o^qdo:2J7rp9K:RkOa#copBQW,-eWIoW>,gSQ"'36K+Dg^Nh'BMhSZh7=nVm3^H4RZ1q2/>g,CUL`B&gG$+%#Q.d->m[N%Hl?A^^qF9adR%)/C.:Z*E3bW(tn=<:a%7K3fIeJ(WUK%dn.TTk8*@1O?lWG<Ag+/]]_f8[Q;SeZd;m;F4LghD[7,IOR[*.73D=5($@P0A^->g,r[NnV==&[SCiucPK:E6Qml.t+I#oPTC_]pcN4WSLu+5FAS!C.H.NUVcHnG@)MUZH/[aQSRa%aUeiAF]![1QnPVYX(Cq[[2P``#4[.fNS22/5hh@C,2ln='r%UlH%Qn#gJ4#%$A5Z=;f5M,@Jnl]_H")Yo1)N/ES9%["&k9%8Ne!BTaCt;KV8I__1eY=p=UR;tAK`E?S#^6SSY0TQ->ECZEgJ-YYR08AWcu>[-I7OM:L3Bt;DF_bcgrEMbHr8VrDr)6ZH0da[hM)AtMLGN-[+)%?pR$[8[>i]u1DX!22WFma&oUCOL_C+pSL7cTU+o5gEElXVhC_45q<#.%eL!am`;%SiR%jsE\(991/AdNklQ025$X&Y:Qjk7r@$l:0sT':2IS>e"sIE1hl^RMVm(ZS[P1Yma1ei/_s-pn6T,X`0E?EigWhRU8+?fTtm))`\_,Fjs^G[6?*.9kTnM9ao<FO9\$*?5aLo2juYO9f-@b:f]VW%>*FpH37V[\>HY(e,5GD<!eRG7ECOp?,I"=3Ao[$-"#&^4^\7]k=eo[974*`#hhRu3D)S1c*=F&'1t&E_):CLS60[F`b_-G*N7ispY9G"<Gm^E0tV3E0E>0n*f?0DX9<RjKo&=;6s=n:Pnt9O2r5]kCkKU%$n)f_e;\S[OS;p9^6n!9e@7-LY%t47f.*Y&jT:fZcYt,=;f.7i%.jP:H'Xb3m6kt;CGX3lK=SEB-$GA;8mPIH[2C005'..5RS'ef[`i`!+3q/:lcGkDq;B7l#>c%%Bb"]BE!pnpK1Zl]qLWHVlp=#X!n%O!cGmk3\i-3Wl)al$4BU]q\;HGFR0LR)2sNs'W$S[u[9.[16E4e#Sb/N/'QEII)b-7'.X.h6OC2tA47[3nC\<s,Fs(WZ8Z\%<X04PuP0-=;XZ6NpKePQ3fqTVcRiT*7#$m/%`eYT1(3j(Gf?MY?<ZH9s]>%"NZ9:;`Mg)R/h>C:(li$o`X0d;e0'DcSoR@X]/A(IXXP38"6/B\T?I@sh)bB':$3Ack;(PNU4qS;<9.2!VMW`Vg58oNh?[ai#gopUGaQqBI(]lZmS-$OG"#)nTkrdGg&)26!g<tH2PU?QEZp^p9<VZFjimd8bj0Zs6`jn=0D4>^N)"p.boQ6>h8C@^lr7^+p%,jbNaUK`X3er#?#CfTt;%,Z$-S!ld:TYaH*GS#G[.TGZ"6\VEb!ljWXd`ZU8\Ak@LS\,?&*!&)nY5C=o2=@^`+fT,`)!H5j>PUOV)b,j;mu(>KnZS0BNIWM]A&R]I@lkl<I)JSQ0i9mXWA(>D04i"a,h:Nli_3OBSZ":FQG6ZI;RXMSNbK"6J$Z19fcT0,n7-Y^0D]$ONb'n<6#Nm,+=bR58TTTo-6=c[nE427)-:C9Da.:>Pe67RqFVA`0T=0Pb,gB$WZ)do&5%!jE]?d\_;u?Z@CNE83.%SX@iW3rO0L^j[_"umst96^'K'dqFs+j?ciQlHh#JOhLBOaRZCp12G4"'%947:J7a'dh!Mke]mU88gc%"_S(f:WQg-JqLVe7PG<7dq^U6kfUq$LhSAOr:Nk7?pq!ihD1&D2ZEt4W~>endstream
-endobj
-119 0 obj
-<<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 146
->>
-stream
-Gaoe40abfP&-VlW`I8r8p8kTb2C,HR"B;1^jessZq0ru$('XtT$%Itfo`/kIdn3H!)]2gFIc?LO/**F"]o=j$k%4uW/sb_b22o:DC]>FD^,an)mT,O;)AA;lT=.Skn`;U9*VV0>Jc#Pr"WY)~>endstream
-endobj
 120 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 139
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1990
 >>
 stream
-Gap@D0a`Rf'L_hJME*uH`-`5&fsS+g8?m#jVN]rp^K;'cGjsW#@B]353IiQPRgD-O$@:`p(;,j$64V:#X*5Hd28/kcq+3NShskQaToNR1&m[+512=4:opNG:Qa(FQ2>IO=%h4U>.K~>endstream
+Gau0CgQ!43&q/A5E$#-T2AW2m]^K'V9`bHEJJ/(+K4!8I[\ZAiO!W$\2IE)omZp>E=O&,+H>H6&+fjnX3N"i/&:W-uJ)1M%eOhrQUP**]l@^q@Lt+`.f;llGKi3pWP9"!&c:Vr5T%5J7^Zc9@TDD%BCm^^5-'>GZH6"iq&q"=jDM(jHn,;856;:<;(eID-3#s:Ai9O\k(>9FFpL/G"O<haW9,4O-5")Z7\>?k$=_O/4C"qEge&>R$9WYVKcJ"F@Fe7`hVo1f)DVWp:L<#)DM_d+F+N"jF\9m)jZ9Gd4q$MYTr]7kC^;I^X(G]0S7L9s'n`90W84OHQJ%JNTBcV"$08odOiB)#[jDo/hIMcCcl_cSO9t,%J]m"D<[oWheQ&7=bp*/M@W4WuKMdGD[O1iSCoT!$)9gECn/R04\X<OWHGK?WEf]e,roRU0IH^Ih(etR.-be'WZ">E,O1T@I8@q;d=iP6*1cPK5kV,p.NX)HUP]508)[E0+q)Ujt9PVGA^;CSJ"O1^E@#*.E.q=3X"#"$hV*UAeHW9h3oaOt=!3uc><""]BLbQ`mN3->/j3B^3ia_9%Q-2T)"Sk_ESJAoGd,^$Y"ROAK)?GF^[WN8"l1aO$;nC_i%T%Np@2``=XV0#Jn.^eet"!tU[I<!t%X!SDjbCG<Wq)Ba]%iY8r$C>dX?#.QIk19nc[O(g>7aAtc*HftUXj:NWe![)W)hYg0nc1)X9*96T;eQ9h6o157=m;jh"MJ[E#/ml>NAUHVInDOsJl<[=oZ,Ue@7!dcNH]6]2frR@(dQLq.k@`%4N98dg4@/#;UA<_XR@8<dYr*8brHGMO^#%EgEp\@lF4Pl2k!snD4qTK]+kALE'j+lS2;$.-jO%F3!NDU92AQ5J^JZ$*K%il-u@1ZU1/tjZ*",u?;omB8\RoYlU'sLp*Om(0liNe@#hq9NT/7?%':B1!JL%q/Q_C/F!,6Smkf[-[OieKO@)WGVNfdCOZ=LE!itGrXH>)U*8$%[m)43]@7WSlWRV$6KIJLHN!O;%Den91iFX]=CLS(m`Xn5LQub/D#1Ks\F%U*AIILXd!HF![c^b9XUc1+C4DG1=FYsO[@AHk,mA0L!blR"1Y[Q1cV;/oQ+Mli`GKR86Y18`sXH:7YWjY7WDn*?rTE)C#$W`J"(+L;eE<3;U0c*<B'F^G6%?Rbb@;J"\ChBYs+DdLlAu/Br(+XL)FU=FoW$S?7.T\(3VS\.-S?%%eOppTEfa55E,#gL#0S0i_fWM.8lf>Ik\RL>>b$X(e)^[$K<bL^8^\YW'*Rar^PR_8SqHU+NY!_j?^Lb%E?gq`mp@#KPE^)G[Iu7?p6[9n7mH(d.muT\>@K^&![]10H'T.mS0mM4rl2fu\m-RaEN2-BIeQD_%8#sc1[QfS\h)pOfJBNRd+ZL)8`]#)IT!\I>IbUd/Zldu_DP<"tX_Lc@J,Xq?CAROE=u+]P*`$M-VF)kg[BD[JYAtMGZiSXSSio?r0Zn?X[L5'._MOW;0;_&ET;iQr47H/^N(&NeFfVsBrbCCS*/thF)[cW>/r?ddc"Safa-6;k=aX50cZq+6G@Il_']PaSrgYmue#jR4HRSc7]>9Dp]kB>nI!OA0])7rIgJ)t66tLjS=+)[;F/MEDHOS#Ib>.!nM*^NH9.,e@g=O5q`#0i#:R/*]9U]]Ylq0.bqVumC.RQ#@iD^ITXc$jjroK-<jBR`3'\sr"?5rk2i@,e.V(V#):[^KN4]cG7&r"bt3:<L*VbK?<+,[_4>-0_REEr5k7g)C2J\Ts&J8i7VLg2s'Ms*6qIXEcb?BkFc[l]n]_no`moS6fQEl4?,@Y4]brWjHC@CQEaqK.$ErpB7G4db`oaP?5*Rrhoa@kKEgTA&^Q8G)[jms,P+8>)LmNnXU.rjtYZ=!SkqCP0Ip+*fCq$[:.tV)X]*?.WC<[e80P%u:/Gc$eqbe+m?%?e*5AZ5Eq!;qPAd+C8V-N\]2Y'T,FjnJ_efD8c~>endstream
 endobj
 121 0 obj
 <<
@@ -2173,12 +2175,26 @@ Gaoe40abfP&-VlW`I8r8p8kTb2C,HR"B;1^jessZq0ru$('XtT$%Itfo`/kIdn3H!)]2gFIc?LO/**F"
 endobj
 138 0 obj
 <<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 139
+>>
+stream
+Gap@D0a`Rf'L_hJME*uH`-`5&fsS+g8?m#jVN]rp^K;'cGjsW#@B]353IiQPRgD-O$@:`p(;,j$64V:#X*5Hd28/kcq+3NShskQaToNR1&m[+512=4:opNG:Qa(FQ2>IO=%h4U>.K~>endstream
+endobj
+139 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 146
+>>
+stream
+Gaoe40abfP&-VlW`I8r8p8kTb2C,HR"B;1^jessZq0ru$('XtT$%Itfo`/kIdn3H!)]2gFIc?LO/**F"]o=j$k%4uW/sb_b22o:DC]>FD^,an)mT,O;)AA;lT=.Skn`;U9*VV0>Jc#Pr"WY)~>endstream
+endobj
+140 0 obj
+<<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 294
 >>
 stream
 Gatm4]5GM?%,CLj2theNU>B(32H,nA)S4)"*4Mm,-?fF(Z4e'DdBOf;J38s<7tN-Tb?O_V;oEiL+Gna&1tRP1]L6pT6rn=Wbjs:e_j/X72TN8<iR5IN'djZ"@qmYqm6#[C$=E$c=enqmgYd?b#=^XQ,m+\='MK(n#T`&5k7uj<"l,JsCWD_6?=%WVi0PZ=C2#Ojg`lG\^3hJc>n"6R\&Ve@hF<_L:A@N'$u,N#i]H/;D!k-Z0@llCr<MZ<AUL:n\oLSPRS]mqWf4,92ntWZ3nEV5I\$f2)uV9r*<~>endstream
 endobj
-139 0 obj
+141 0 obj
 <<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 602
 >>
@@ -2186,7 +2202,7 @@ stream
 GatU/a_olf%))NgGYD=D&Oe;$Z"Yt!O@rClHBi>AiRT&/*iIn&g62iK9FDQ>!/hI95/'Mo6-I(:h[BK$'qB1Rcp4uB[)t^X%9HPL>G+9c[&<S1#Z3Sqr;F=gHo"O8\$8ut@VB&b-8g@:h,\T6'5!eGL"d@qa5Wu3HW7mP&a9;6;$Bb.`4@P55t0'?TU<AI7QW")[IPIX-nV_keE.)0Q<[pp%lr7[-?)[+[Q`n9k>:?'T0dm[b%gQFC8L#JYCTGc,gUVoVTC.mc.6b72`>5W,<!l@9@4IV)%4GE$-%5*Ide9h24U=b/+XtVlIW(dqHc^Tn=a`uUfN+Ic+MNG]$[g-%;2/Egs%NsF._>To`M5'9.b'm*:f3W64FI%/H:kB"fGVTX&A/J%Tr\-Oq;$AOk6I-*3;M(3jPWm-8%m<j!5_l^.@l):/"1W'#pLQo7#?<H"te.-![6pmY5`(@XgrG<;1+Y,["BL>oqGd;p;;NgQ+EET8@WP]E$?/YXe)J%4E/Q7PAKf;P8MsnF`r5[/uhHS@Wm;q(_PjpM9+WYs5)BBt%;i5L6=t(?8&Zme3X+_i)Nr[Q$+`nP+>S8e\di3>?rC]%ZjO~>endstream
 endobj
 xref
-0 140
+0 142
 0000000000 65535 f 
 0000000073 00000 n 
 0000000256 00000 n 
@@ -2231,112 +2247,114 @@ xref
 0000300473 00000 n 
 0000318148 00000 n 
 0000338917 00000 n 
-0000339783 00000 n 
-0000340054 00000 n 
-0000340325 00000 n 
-0000340596 00000 n 
-0000340867 00000 n 
-0000341138 00000 n 
-0000341409 00000 n 
-0000341680 00000 n 
-0000341951 00000 n 
-0000342222 00000 n 
-0000342493 00000 n 
-0000342764 00000 n 
-0000343035 00000 n 
-0000343306 00000 n 
-0000343577 00000 n 
-0000343848 00000 n 
-0000344119 00000 n 
-0000344390 00000 n 
-0000344661 00000 n 
-0000344932 00000 n 
-0000345203 00000 n 
-0000345570 00000 n 
-0000346351 00000 n 
-0000374782 00000 n 
-0000375002 00000 n 
-0000376348 00000 n 
-0000377145 00000 n 
-0000395756 00000 n 
-0000396002 00000 n 
-0000397209 00000 n 
-0000398000 00000 n 
-0000445071 00000 n 
-0000445314 00000 n 
-0000446480 00000 n 
-0000447268 00000 n 
-0000467962 00000 n 
-0000468207 00000 n 
-0000469414 00000 n 
-0000470195 00000 n 
-0000492149 00000 n 
-0000492382 00000 n 
-0000493593 00000 n 
-0000494381 00000 n 
-0000513798 00000 n 
-0000514041 00000 n 
-0000515208 00000 n 
-0000516004 00000 n 
-0000541062 00000 n 
-0000541315 00000 n 
-0000542524 00000 n 
-0000543313 00000 n 
-0000570372 00000 n 
-0000570615 00000 n 
-0000571822 00000 n 
-0000572614 00000 n 
-0000586009 00000 n 
-0000586253 00000 n 
-0000587418 00000 n 
-0000588240 00000 n 
-0000606552 00000 n 
-0000606793 00000 n 
-0000608198 00000 n 
-0000608992 00000 n 
-0000622310 00000 n 
-0000622518 00000 n 
-0000623255 00000 n 
-0000623327 00000 n 
-0000623625 00000 n 
-0000623881 00000 n 
-0000624575 00000 n 
-0000625446 00000 n 
-0000625912 00000 n 
-0000626349 00000 n 
-0000628473 00000 n 
-0000630893 00000 n 
-0000632802 00000 n 
-0000633040 00000 n 
-0000633271 00000 n 
-0000633509 00000 n 
-0000633740 00000 n 
-0000633978 00000 n 
-0000634209 00000 n 
-0000634447 00000 n 
-0000634678 00000 n 
-0000634916 00000 n 
-0000635147 00000 n 
-0000635385 00000 n 
-0000635616 00000 n 
-0000635854 00000 n 
-0000636085 00000 n 
-0000636323 00000 n 
-0000636554 00000 n 
-0000636792 00000 n 
-0000637023 00000 n 
-0000637261 00000 n 
-0000637647 00000 n 
+0000339162 00000 n 
+0000340679 00000 n 
+0000341594 00000 n 
+0000341865 00000 n 
+0000342136 00000 n 
+0000342407 00000 n 
+0000342678 00000 n 
+0000342949 00000 n 
+0000343220 00000 n 
+0000343491 00000 n 
+0000343762 00000 n 
+0000344033 00000 n 
+0000344304 00000 n 
+0000344575 00000 n 
+0000344846 00000 n 
+0000345117 00000 n 
+0000345388 00000 n 
+0000345659 00000 n 
+0000345930 00000 n 
+0000346201 00000 n 
+0000346472 00000 n 
+0000346743 00000 n 
+0000347014 00000 n 
+0000347381 00000 n 
+0000348162 00000 n 
+0000376593 00000 n 
+0000376813 00000 n 
+0000378159 00000 n 
+0000378956 00000 n 
+0000397567 00000 n 
+0000397813 00000 n 
+0000399020 00000 n 
+0000399811 00000 n 
+0000446882 00000 n 
+0000447125 00000 n 
+0000448291 00000 n 
+0000449079 00000 n 
+0000469773 00000 n 
+0000470018 00000 n 
+0000471225 00000 n 
+0000472006 00000 n 
+0000493960 00000 n 
+0000494193 00000 n 
+0000495404 00000 n 
+0000496192 00000 n 
+0000515609 00000 n 
+0000515852 00000 n 
+0000517019 00000 n 
+0000517815 00000 n 
+0000542873 00000 n 
+0000543126 00000 n 
+0000544335 00000 n 
+0000545124 00000 n 
+0000572183 00000 n 
+0000572426 00000 n 
+0000573633 00000 n 
+0000574425 00000 n 
+0000587821 00000 n 
+0000588067 00000 n 
+0000589233 00000 n 
+0000590055 00000 n 
+0000608367 00000 n 
+0000608608 00000 n 
+0000610013 00000 n 
+0000610807 00000 n 
+0000624125 00000 n 
+0000624333 00000 n 
+0000625070 00000 n 
+0000625142 00000 n 
+0000625440 00000 n 
+0000625696 00000 n 
+0000626390 00000 n 
+0000627261 00000 n 
+0000627727 00000 n 
+0000628164 00000 n 
+0000630288 00000 n 
+0000632708 00000 n 
+0000634791 00000 n 
+0000635029 00000 n 
+0000635260 00000 n 
+0000635498 00000 n 
+0000635729 00000 n 
+0000635967 00000 n 
+0000636198 00000 n 
+0000636436 00000 n 
+0000636667 00000 n 
+0000636905 00000 n 
+0000637136 00000 n 
+0000637374 00000 n 
+0000637605 00000 n 
+0000637843 00000 n 
+0000638074 00000 n 
+0000638312 00000 n 
+0000638543 00000 n 
+0000638781 00000 n 
+0000639012 00000 n 
+0000639250 00000 n 
+0000639636 00000 n 
 trailer
 <<
 /ID 
-[<9d06a086381a143f9e012eadbf9dfe30><9d06a086381a143f9e012eadbf9dfe30>]
+[<5de4b429f7efe97b150f36d3718cebb9><5de4b429f7efe97b150f36d3718cebb9>]
 % ReportLab generated PDF document -- digest (http://www.reportlab.com)
 
-/Info 110 0 R
-/Root 109 0 R
-/Size 140
+/Info 112 0 R
+/Root 111 0 R
+/Size 142
 >>
 startxref
-638341
+640330
 %%EOF

--- a/tests/unittest_fotobook_mcf-Dateien/folderid.xml
+++ b/tests/unittest_fotobook_mcf-Dateien/folderid.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<mcfkey folderID="9e29b965-4ee3-49c6-9a03-8f20497b87d8" padding="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"/>
+<mcfkey folderID="08049b6a-92c9-4c7b-9bba-e4ede342c757" padding="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"/>


### PR DESCRIPTION
I observe that we have different coding conventions. One way to handle this in a team project (and especially a project with relatively inexperienced Python programmers such as myself!) is to use code analysis to check the code against a set of rules. Visual Studio incorporates the _pylint_ and _mypy_ tools; I have tried _pylint_. As a trial I have made some "trivial" changes in the files associated with this pull request, based on _pylint_'s suggestions. Mostly removal of trailing white space, correction of indentation which was not a multiple of 4 spaces, removed a couple of unnecessary parentheses. I have also chosen to suppress the invalid-name message in the _pylint_ configuration file because we do not use snake-case names.

This first set of changes is really just an attempt to start a discussion, though we should probably pay more attention to the remaining 34 error level and 53 warning level messages. Things like use of incompatible types are probably important!

One specific question - how long should we allow code lines to be? The default for _pylint_ to complain is 100 characters, we have over 100 lines which are longer than that, 8 of them are over 150 characters.