### PR TITLE
Support downloaded cliparts, masks and backgrounds

### DIFF
--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -303,7 +303,7 @@ def processAreaImageTag(imageTag, area, areaHeight, areaRot, areaWidth, imagedir
             pptXmlInfo = Passepartout.extractInfoFromXml(pptXmlFileName, passepartoutid)
             frameClipartFileName = Passepartout.getClipartFullName(pptXmlInfo)
             maskClipartFileName = Passepartout.getMaskFullName(pptXmlInfo)
-            print("Using clipart file: {}".format(frameClipartFileName))
+            print("Using mask file: {}".format(maskClipartFileName))
             # draw the passepartout clipart file.
             # ToDo: apply the masking
             frameAlpha = 255

--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -1037,6 +1037,7 @@ def SetEnvironmentVariables(cewe_folder, defaultConfigSection):
 
 
 def convertMcf(mcfname, keepDoublePages: bool):
+    global passepartoutFolders  # pylint: disable=global-statement
     # Get the folder in which the .mcf file is
     mcfPathObj = Path(mcfname).resolve()    # convert it to an absolute path
     mcfBaseFolder = str(mcfPathObj.parent)
@@ -1062,6 +1063,10 @@ def convertMcf(mcfname, keepDoublePages: bool):
         cewe_file.close()
         baseBackgroundLocations = getBaseBackgroundLocations(cewe_folder)
         backgroundLocations = baseBackgroundLocations
+
+        dotMcfPath = os.path.expanduser("~/.mcf/hps/");
+        if os.path.exists(dotMcfPath):
+            passepartoutFolders = glob.glob(dotMcfPath + "/*/addons/")
     except: # noqa: E722
         print('Cannot find cewe installation folder from cewe_folder.txt, trying cewe2pdf.ini from current directory and from .mcf directory.')
         configuration = configparser.ConfigParser()
@@ -1107,7 +1112,6 @@ def convertMcf(mcfname, keepDoublePages: bool):
             pptout_rawFolder.append(cewe_folder)    # add the base folder
             pptout_filtered1 = list(filter(lambda bg: (len(bg) != 0), pptout_rawFolder)) # filter out empty entries
             pptout_filtered2 = tuple(map(lambda bg: os.path.expandvars(bg), pptout_filtered1)) # expand environment vars pylint: disable=unnecessary-lambda
-            global passepartoutFolders  # pylint: disable=global-statement
             passepartoutFolders = pptout_filtered2
 
     bg_notFoundDirList = set([])   # keep a list with background folders that not found, to prevent multiple errors for the same cause.

--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -300,7 +300,7 @@ def processAreaImageTag(imageTag, area, areaHeight, areaRot, areaWidth, imagedir
             print("Error can't find passepartout for {}".format(passepartoutid))
         else:
             pptXmlFileName = passepartoutDict[passepartoutid]
-            pptXmlInfo = Passepartout.extractInfoFromXml(pptXmlFileName)
+            pptXmlInfo = Passepartout.extractInfoFromXml(pptXmlFileName, passepartoutid)
             frameClipartFileName = Passepartout.getClipartFullName(pptXmlInfo)
             maskClipartFileName = Passepartout.getMaskFullName(pptXmlInfo)
             print("Using clipart file: {}".format(frameClipartFileName))
@@ -1066,7 +1066,7 @@ def convertMcf(mcfname, keepDoublePages: bool):
 
         dotMcfPath = os.path.expanduser("~/.mcf/hps/");
         if os.path.exists(dotMcfPath):
-            passepartoutFolders = glob.glob(dotMcfPath + "/*/addons/")
+            passepartoutFolders = glob.glob(dotMcfPath + "/*/addons/") + [cewe_folder + "Resources/photofun/decorations"]
             backgroundLocations = backgroundLocations + tuple(glob.glob(dotMcfPath + "/*/addons/*/backgrounds/v1/backgrounds/")) + tuple(glob.glob(dotMcfPath + "/*/addons/*/backgrounds/v1/"))
     except: # noqa: E722
         print('Cannot find cewe installation folder from cewe_folder.txt, trying cewe2pdf.ini from current directory and from .mcf directory.')

--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -51,6 +51,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # extend the search path so Cairo will find its dlls.
 # only needed when the program is frozen (i.e. compiled).
 import sys
+import glob
 import logging
 import os.path
 import os
@@ -982,13 +983,25 @@ def readClipArtConfigXML(baseFolder):
         print('Cliparts will not be available.')
         return
 
+    loadClipartConfigXML(xmlFileName)
+
+def readClipArtDownloads():
+    dotMcfPath = os.path.expanduser("~/.mcf/hps/");
+    if not os.path.exists(dotMcfPath):
+        print("~/.mcf not found")
+        return
+
+    for file in glob.glob(dotMcfPath + "/*/addons/*/cliparts/v1/decorations/*.xml"):
+        loadClipartConfigXML(file)
+
+def loadClipartConfigXML(xmlFileName):
     clipArtXml = open(xmlFileName, 'rb')
     xmlInfo = etree.parse(xmlFileName)
     clipArtXml.close()
 
     for decoration in xmlInfo.findall('decoration'):
         clipartElement = decoration.find('clipart')
-        fileName = clipartElement.get('file')
+        fileName = os.path.join(os.path.dirname(xmlFileName), clipartElement.get('file'))
         designElementId = int(clipartElement.get('designElementId'))    # assume these IDs are always integers.
         clipartDict[designElementId] = fileName
     return
@@ -1161,6 +1174,7 @@ def convertMcf(mcfname, keepDoublePages: bool):
 
     # generate a list of available clip-arts
     readClipArtConfigXML(cewe_folder)
+    readClipArtDownloads()
 
     for n in range(pageCount):
         try:

--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -308,10 +308,11 @@ def processAreaImageTag(imageTag, area, areaHeight, areaRot, areaWidth, imagedir
             # ToDo: apply the masking
             frameAlpha = 255
             # Adjust the position of the real image depending on the frame
-            frameDeltaX_mcfunit = pptXmlInfo.fotoarea_x * areaWidth
-            frameDeltaY_mcfunit = pptXmlInfo.fotoarea_y * areaHeight
-            imgCropWidth_mcfunit = pptXmlInfo.fotoarea_width * areaWidth
-            imgCropHeight_mcfunit = pptXmlInfo.fotoarea_height * areaHeight
+            if pptXmlInfo.fotoarea_x is not None:
+                frameDeltaX_mcfunit = pptXmlInfo.fotoarea_x * areaWidth
+                frameDeltaY_mcfunit = pptXmlInfo.fotoarea_y * areaHeight
+                imgCropWidth_mcfunit = pptXmlInfo.fotoarea_width * areaWidth
+                imgCropHeight_mcfunit = pptXmlInfo.fotoarea_height * areaHeight
 
     # without cropping: to get from a image pixel width to the areaWidth in .mcf-units, the image pixel width is multiplied by the scale factor.
     # to get from .mcf units are divided by the scale factor to get to image pixel units.

--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -1067,6 +1067,7 @@ def convertMcf(mcfname, keepDoublePages: bool):
         dotMcfPath = os.path.expanduser("~/.mcf/hps/");
         if os.path.exists(dotMcfPath):
             passepartoutFolders = glob.glob(dotMcfPath + "/*/addons/")
+            backgroundLocations = backgroundLocations + tuple(glob.glob(dotMcfPath + "/*/addons/*/backgrounds/v1/backgrounds/")) + tuple(glob.glob(dotMcfPath + "/*/addons/*/backgrounds/v1/"))
     except: # noqa: E722
         print('Cannot find cewe installation folder from cewe_folder.txt, trying cewe2pdf.ini from current directory and from .mcf directory.')
         configuration = configparser.ConfigParser()

--- a/clpFile.py
+++ b/clpFile.py
@@ -128,7 +128,17 @@ class ClpFile(object):
         #  if the .svg is fully filled by the mask, then only a black rectangle with RGA (=no background!) is returned.
         #  if the mask does not fully fill the mask, then an RGBA image is returned. In this case, use the alpha value directly.
         if maskImgPng.mode == "RGBA":
-            alphaChannel = maskImgPng.getchannel("A")
+            # an RGBA image mask does not always use transparency
+            # some images still use white to indicate transparent parts
+            # to support both transparent and white RGBA svg masks,
+            # convert transparency to white and use white as alpha channel.
+            #alphaChannel = maskImgPng.getchannel("A")
+            #maskImgPng.paste("white", None, "RGBA")
+
+            white = PIL.Image.new("RGBA", maskImgPng.size, "WHITE")
+            white.paste(maskImgPng, (0, 0), maskImgPng)
+            alphaChannel = white.convert('L')
+            alphaChannel = PIL.ImageOps.invert(alphaChannel)
         elif maskImgPng.mode == "RGB":
             # convert image to gray-scale and use that as alpha channel.
             # we need to invert, otherwise black whould be transparent.

--- a/clpFile.py
+++ b/clpFile.py
@@ -88,7 +88,7 @@ class ClpFile(object):
         # create a byte buffer that can be used like a file and use it as the output of svg2png.
         tmpMemFile = BytesIO()
         # Step 1.
-        cairosvg.svg2png(bytestring=self.svgData, write_to=tmpMemFile)
+        cairosvg.svg2png(bytestring=self.svgData, write_to=tmpMemFile, unsafe=True)
         tmpMemFile.seek(0)
         tempImage = PIL.Image.open(tmpMemFile)
         origWidth = tempImage.width
@@ -99,7 +99,7 @@ class ClpFile(object):
         # Step 3.
         scaleMax = max(scale_x, scale_y)
         tmpMemFile = BytesIO()
-        cairosvg.svg2png(bytestring=self.svgData, write_to=tmpMemFile, scale=scaleMax)
+        cairosvg.svg2png(bytestring=self.svgData, write_to=tmpMemFile, scale=scaleMax, unsafe=True)
         # Step 4.
         tmpMemFile.seek(0)
         tempImage = PIL.Image.open(tmpMemFile)

--- a/passepartout.py
+++ b/passepartout.py
@@ -39,7 +39,14 @@ class Passepartout(object):
         fotoarea_y: float
 
     @staticmethod
-    def extractInfoFromXml(xmlFileName: str):
+    def extractInfoFromXml(xmlFileName: str, passepartoutid: int):
+        for xmlInfo in Passepartout.extractAllInfosFromXml(xmlFileName):
+            if xmlInfo.designElementId == passepartoutid:
+                return xmlInfo
+        return None
+
+    @staticmethod
+    def extractAllInfosFromXml(xmlFileName: str):
         # read information from xml file about passepartout
 
         clipArtXml = open(xmlFileName, 'rb')
@@ -85,7 +92,7 @@ class Passepartout(object):
                 fotoarea_x = None
                 fotoarea_y = None
 
-            return Passepartout.decorationXmlInfo(xmlFileName, designElementId, decoration_id, decoration_type,
+            yield Passepartout.decorationXmlInfo(xmlFileName, designElementId, decoration_id, decoration_type,
                             designElementType, maskFile, clipartFile,
                             fotoarea_height, fotoarea_width, fotoarea_x, fotoarea_y)
         return None
@@ -123,12 +130,12 @@ class Passepartout(object):
         # load each .xml file and extract the information
         for curXmlFile in xmlFileList:
             # print("Parsing passepartout: {}".format(curXmlFile))
-            xmlInfo = Passepartout.extractInfoFromXml(curXmlFile)
-            if xmlInfo is None:
-                continue  # this .xml file is not for a passepartout, or something went wrong
-            if xmlInfo.designElementType == 'passepartout':
-                # print("Adding passepartout to dict: {}".format(curXmlFile))
-                passepartoutIdDict[xmlInfo.designElementId] = curXmlFile
+            for xmlInfo in Passepartout.extractAllInfosFromXml(curXmlFile):
+                if xmlInfo is None:
+                    continue  # this .xml file is not for a passepartout, or something went wrong
+                if xmlInfo.designElementType == 'passepartout':
+                    # print("Adding passepartout to dict: {}".format(curXmlFile))
+                    passepartoutIdDict[xmlInfo.designElementId] = curXmlFile
 
         return passepartoutIdDict
 
@@ -157,7 +164,7 @@ if __name__ == '__main__':
         [r"C:\ProgramData\hps\1320",
          "C:/Program Files/dm/dm-Fotowelt/Resources/photofun/decorations"])
     testId = 125186
-    testXmlInfo = Passepartout.extractInfoFromXml(myDict[testId])
+    testXmlInfo = Passepartout.extractInfoFromXml(myDict[testId], testId)
     print(testId)
     print(testXmlInfo)
     print(Passepartout.getClipartFullName(testXmlInfo))

--- a/passepartout.py
+++ b/passepartout.py
@@ -52,24 +52,38 @@ class Passepartout(object):
             clipArtXml.close()
 
         for decoration in xmlInfo.findall('decoration'):
-            # assume these IDs are always integers.
-            designElementId = decoration.get('designElementId')
-            if designElementId is None:
-                continue
-            designElementId = int(designElementId)
             decoration_id = decoration.get('id')
             decoration_type = decoration.get('type')
             # decoration_type is often "fading", so typeElement is then looking for <fading .../>
             typeElement = decoration.find(decoration_type)
+            if typeElement is None:
+                continue;
+            # assume these IDs are always integers.
+            designElementId = decoration.get('designElementId')
+            if designElementId is None:
+                designElementId = typeElement.get('designElementId')
+                if designElementId is None:
+                    continue
+            designElementId = int(designElementId)
+
             designElementType = typeElement.get('designElementType')
             maskFile = typeElement.get('file')
             clipartElement = typeElement.find('clipart')
-            clipartFile = clipartElement.get('file')
+            if clipartElement is not None:
+                clipartFile = clipartElement.get('file')
+            else:
+                clipartFile = None
             fotoareaElement = typeElement.find('fotoarea')
-            fotoarea_height = float(fotoareaElement.get('height'))
-            fotoarea_width = float(fotoareaElement.get('width'))
-            fotoarea_x = float(fotoareaElement.get('x'))
-            fotoarea_y = float(fotoareaElement.get('y'))
+            if fotoareaElement is not None:
+                fotoarea_height = float(fotoareaElement.get('height'))
+                fotoarea_width = float(fotoareaElement.get('width'))
+                fotoarea_x = float(fotoareaElement.get('x'))
+                fotoarea_y = float(fotoareaElement.get('y'))
+            else:
+                fotoarea_height = None
+                fotoarea_width = None
+                fotoarea_x = None
+                fotoarea_y = None
 
             return Passepartout.decorationXmlInfo(xmlFileName, designElementId, decoration_id, decoration_type,
                             designElementType, maskFile, clipartFile,
@@ -120,6 +134,8 @@ class Passepartout(object):
 
     @staticmethod
     def getPassepartoutFileFullName(xmlInfo:decorationXmlInfo, fileName:str) -> str:
+        if fileName is None:
+            return None
         pathObj = Path(xmlInfo.srcXmlFile)
         # should not be needed: pathObj = pathObj.resolve()    # convert it to an absolute path
         basePath = pathObj.parent


### PR DESCRIPTION
dm fotowelt downloads additional files to `~/.mcf`.
These patches here load the mask, background and clipart files from there.

The downloaded masks are a bit different than the normal masks: The designElementId is not always on the decoration element, and they don't always have a clipart file or a foto area.

The svg files also sometimes use XML entities, which is why we need to enable unsafe xml parsing for cairosvg.

Resolves #76 and #78.