### PR TITLE
Fixes the crash mentioned in https://github.com/bash0/cewe2pdf/pull/97

### DIFF
--- a/tests/cewe2pdf.ini
+++ b/tests/cewe2pdf.ini
@@ -1,13 +1,15 @@
 [DEFAULT]
 cewe_folder = C:\Program Files\Elkjop fotoservice_6.3\elkjop fotoservice
-extraBackgroundFolders = 
-	${PROGRAMDATA}/hps/${KEYACCOUNT}/addons/447/backgrounds/v1/backgrounds
-	${PROGRAMDATA}/hps/${KEYACCOUNT}/addons/448/backgrounds/v1/backgrounds
-	Resources/photofun/backgrounds
-	tests/Resources/photofun/backgrounds
-extraClipArts = 
-	63488, ${PROGRAMDATA}/hps/${KEYACCOUNT}/addons/63488/cliparts/v1/decorations/rect_cream.clp
-	121285, ${PROGRAMDATA}/hps/${KEYACCOUNT}/addons/121285/cliparts/v1/decorations/12089-clip-gold-gd.clp
 fontFamilies =
 	Bodoni,Bodoni,BodoniB,BodoniI,BodoniBI
-passepartoutFolders=${PROGRAMDATA}/hps
+
+# These explicit additions are no longer necessary after Christian Weike's improvements in July 2021
+#extraBackgroundFolders = 
+#	${PROGRAMDATA}/hps/${KEYACCOUNT}/addons/447/backgrounds/v1/backgrounds
+#	${PROGRAMDATA}/hps/${KEYACCOUNT}/addons/448/backgrounds/v1/backgrounds
+#	Resources/photofun/backgrounds
+#	tests/Resources/photofun/backgrounds
+#extraClipArts = 
+#	63488, ${PROGRAMDATA}/hps/${KEYACCOUNT}/addons/63488/cliparts/v1/decorations/rect_cream.clp
+#	121285, ${PROGRAMDATA}/hps/${KEYACCOUNT}/addons/121285/cliparts/v1/decorations/12089-clip-gold-gd.clp
+#passepartoutFolders=${PROGRAMDATA}/hps

--- a/tests/cewe2pdf.ini
+++ b/tests/cewe2pdf.ini
@@ -1,9 +1,9 @@
 [DEFAULT]
 cewe_folder = C:\Program Files\Elkjop fotoservice_6.3\elkjop fotoservice
-fontFamilies =
-	Bodoni,Bodoni,BodoniB,BodoniI,BodoniBI
 
 # These explicit additions are no longer necessary after Christian Weike's improvements in July 2021
+#fontFamilies =
+#	Bodoni,Bodoni,BodoniB,BodoniI,BodoniBI
 #extraBackgroundFolders = 
 #	${PROGRAMDATA}/hps/${KEYACCOUNT}/addons/447/backgrounds/v1/backgrounds
 #	${PROGRAMDATA}/hps/${KEYACCOUNT}/addons/448/backgrounds/v1/backgrounds


### PR DESCRIPTION
removes a manual fontfamilies definition in the unittext