### PR TITLE
Logging introduced instead of print statements, ref https://github.com/bash0/cewe2pdf/issues/82

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,6 @@ nosetests.xml
 /tests/unittest_fotobook.mcf.20200516.pdf
 /tests/unittest_fotobook.mcf.20201217.pdf
 /tests/unittest_fotobook.mcf.20210202.pdf
+/tests/unittest_fotobook.mcf.20210725.pdf
 /Output/cewe2pdfsetup.exe
 /cewe2pdf.iss

--- a/cewe2pdf.pyproj
+++ b/cewe2pdf.pyproj
@@ -28,8 +28,10 @@
     <Content Include="build_a_compiled_version.md" />
     <Content Include="cewe2pdf.ini" />
     <Content Include="CLP file format.txt" />
+    <Content Include="loggerconfig.yaml" />
     <Content Include="README.md" />
     <Content Include="requirements.txt" />
+    <Content Include="tests\additional_fonts.txt" />
     <Content Include="tests\cewe2pdf.ini" />
     <Content Include="tests\unittest_fotobook.mcf" />
     <Content Include="tests\unittest_fotobook.mcf.pdf" />

--- a/loggerconfig.yaml
+++ b/loggerconfig.yaml
@@ -1,0 +1,23 @@
+version: 1
+formatters:
+  simple:
+    format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    datefmt: '%H:%M:%S'
+handlers:
+  console:
+    class: logging.StreamHandler
+    level: DEBUG
+    formatter: simple
+    stream: ext://sys.stdout
+loggers:
+  cewe2pdf.config:
+    level: WARNING
+    handlers: [console]
+    propagate: no
+  PIL.PngImagePlugin:
+    level: WARNING
+    handlers: [console]
+    propagate: no
+root:
+  level: INFO
+  handlers: [console]

--- a/passepartout.py
+++ b/passepartout.py
@@ -13,6 +13,7 @@ import os
 import os.path
 import cairosvg
 import PIL
+import logging
 from PIL.ExifTags import TAGS
 from io import BytesIO
 from clpFile import ClpFile
@@ -20,6 +21,7 @@ from typing import List, Set, Dict, Tuple, Optional
 from lxml import etree
 from typing import NamedTuple
 
+configlogger = logging.getLogger("cewe2pdf.config")
 
 class Passepartout(object):
     def __init__(self):
@@ -53,7 +55,7 @@ class Passepartout(object):
         try:
             xmlInfo = etree.parse(xmlFileName)
         except: # noqa: E722
-            print("Error while parsing. Maybe not valid XML:{}".format(xmlFileName))
+            logging.error("Maybe not valid XML:{}".format(xmlFileName))
             return None
         finally:
             clipArtXml.close()
@@ -106,7 +108,7 @@ class Passepartout(object):
         passepartoutIdDict = dict()
 
         if directoryList is None:
-            print("Error: no directories passed to Passepartout.buildElementIdIndex!")
+            configlogger.error("No directories passed to Passepartout.buildElementIdIndex!")
             return passepartoutIdDict
 
         if isinstance(directoryList, tuple):
@@ -115,7 +117,7 @@ class Passepartout(object):
         if not isinstance(directoryList, list):
             directoryList = [directoryList]
 
-        print("Refreshing decoration designElementId index.")
+        configlogger.info("Refreshing decoration designElementId index.")
 
         # generate list of .xml files
         xmlFileList = []
@@ -125,7 +127,7 @@ class Passepartout(object):
                 for filename in (f for f in filenames if f.endswith(ext)):
                     xmlFileList.append(os.path.join(dirpath, filename))
                     # print(os.path.join(dirpath, filename))
-        print("Found {:d} XML files.".format(len(xmlFileList)))
+        configlogger.info("Found {:d} XML files.".format(len(xmlFileList)))
 
         # load each .xml file and extract the information
         for curXmlFile in xmlFileList:

--- a/tests/additional_fonts.txt
+++ b/tests/additional_fonts.txt
@@ -1,0 +1,9 @@
+# All fonts delivered by CEWE are added automatically
+# Adding the entire windows fonts directory is definitely overkill, so just pick the ones we want
+Arial = C:\WINDOWS\FONTS\ARIAL.TTF
+Arial Rounded MT Bold = C:\WINDOWS\FONTS\ARLRDBD.TTF
+CalligraphScript = C:\Windows\Fonts\PALSCRI.TTF
+FranklinGothic = C:\Windows\Fonts\framd.ttf
+Calibri = C:\Windows\Fonts\calibri.ttf
+Segoe UI Symbol = C:\Windows\Fonts\seguisym.ttf
+Function = ${CEWE_FOLDER}\Resources\photofun\fonts\Function-Light.ttf

--- a/tests/cewe2pdf.ini
+++ b/tests/cewe2pdf.ini
@@ -1,13 +1,15 @@
 [DEFAULT]
 cewe_folder = C:\Program Files\Elkjop fotoservice_6.3\elkjop fotoservice
-extraBackgroundFolders = 
-	${PROGRAMDATA}/hps/${KEYACCOUNT}/addons/447/backgrounds/v1/backgrounds
-	${PROGRAMDATA}/hps/${KEYACCOUNT}/addons/448/backgrounds/v1/backgrounds
-	Resources/photofun/backgrounds
-	tests/Resources/photofun/backgrounds
-extraClipArts = 
-	63488, ${PROGRAMDATA}/hps/${KEYACCOUNT}/addons/63488/cliparts/v1/decorations/rect_cream.clp
-	121285, ${PROGRAMDATA}/hps/${KEYACCOUNT}/addons/121285/cliparts/v1/decorations/12089-clip-gold-gd.clp
 fontFamilies =
 	Bodoni,Bodoni,BodoniB,BodoniI,BodoniBI
-passepartoutFolders=${PROGRAMDATA}/hps
+
+# These explicit additions are no longer necessary after Christian Weike's improvements in July 2021
+#extraBackgroundFolders = 
+#	${PROGRAMDATA}/hps/${KEYACCOUNT}/addons/447/backgrounds/v1/backgrounds
+#	${PROGRAMDATA}/hps/${KEYACCOUNT}/addons/448/backgrounds/v1/backgrounds
+#	Resources/photofun/backgrounds
+#	tests/Resources/photofun/backgrounds
+#extraClipArts = 
+#	63488, ${PROGRAMDATA}/hps/${KEYACCOUNT}/addons/63488/cliparts/v1/decorations/rect_cream.clp
+#	121285, ${PROGRAMDATA}/hps/${KEYACCOUNT}/addons/121285/cliparts/v1/decorations/12089-clip-gold-gd.clp
+#passepartoutFolders=${PROGRAMDATA}/hps

--- a/tests/cewe2pdf.ini
+++ b/tests/cewe2pdf.ini
@@ -1,9 +1,9 @@
 [DEFAULT]
 cewe_folder = C:\Program Files\Elkjop fotoservice_6.3\elkjop fotoservice
-fontFamilies =
-	Bodoni,Bodoni,BodoniB,BodoniI,BodoniBI
 
 # These explicit additions are no longer necessary after Christian Weike's improvements in July 2021
+#fontFamilies =
+#	Bodoni,Bodoni,BodoniB,BodoniI,BodoniBI
 #extraBackgroundFolders = 
 #	${PROGRAMDATA}/hps/${KEYACCOUNT}/addons/447/backgrounds/v1/backgrounds
 #	${PROGRAMDATA}/hps/${KEYACCOUNT}/addons/448/backgrounds/v1/backgrounds


### PR DESCRIPTION
There is a discussion in https://github.com/bash0/cewe2pdf/issues/82 about how we should organize (or not) log messages. This is my suggestion. After doing the actual work I concede Christian's point that dividing into several logical logging topics feels a bit like overkill. However, I still think that logging related to the initial one-time processing of all the various configuration files would be nice to keep quiet even when using more detailed logging of the actual page processing. So my implementation uses the root logger for everything except configuration handling, which has been given a named logger. In that way we can increase the detail of the root logging without drowning in configuration stuff, which can really be quite significant as we read in fonts, clipart definitions, etc.
The significant changes are in the commit https://github.com/bash0/cewe2pdf/pull/99/commits/0691c90c7792f3a85bca73543a8f82dbad1673c6
The remaining commits are either "admin merges" or minor changes related to the recent improvements in font processing.
It is now much easier to see that the processing of one of my own albums is "clean", as the log below, made with the default logging configuration, shows. I can't seem to request you as a reviewer @cweiske, but I'd appreciate it if you could take a look?
```
(base) D:\Users\pete\Source\GitHub\cewe2pdf>py cewe2pdf.py "d:\users\pete\Documents\Fotobooks\PhotoAlbum2020 - Copy.mcf"
14:42:34 - root - INFO - Could not find ['cewe_folder.txt'] in D:\Users\pete\Documents\Fotobooks, . paths
14:42:34 - root - INFO - Trying cewe2pdf.ini from current directory and from .mcf directory.
14:42:34 - root - INFO - Using configuration in: cewe2pdf.ini, D:\Users\pete\Documents\Fotobooks\cewe2pdf.ini
14:42:34 - root - INFO - Using fonts from: D:\Users\pete\Documents\Fotobooks\additional_fonts.txt
14:42:34 - cewe2pdf.config - WARNING - Unhandled font subfamily: Function Light Light
14:42:34 - cewe2pdf.config - WARNING - Unhandled font subfamily: Balloon Caps Xbold Xbold
14:42:34 - cewe2pdf.config - WARNING - Unhandled font subfamily: Canossa Light Light
14:42:34 - cewe2pdf.config - WARNING - Unhandled font subfamily: Copperplate Gothic Light Light
14:42:34 - cewe2pdf.config - WARNING - Unhandled font subfamily: Dessau Light Light
14:42:34 - cewe2pdf.config - WARNING - Unhandled font subfamily: Falcon Light Light
14:42:34 - cewe2pdf.config - WARNING - Unhandled font subfamily: Pecita Book Book
14:42:34 - cewe2pdf.config - WARNING - Unhandled font subfamily: Stafford Light Light
14:42:34 - cewe2pdf.config - WARNING - Unhandled font subfamily: TiogaScript Light Light
14:42:34 - root - INFO - Registering 76 fonts
14:42:34 - root - INFO - Ended  font registration
14:42:34 - root - INFO - parsing page 0  of 40
14:42:36 - root - INFO - parsing page 1  of 40
14:42:36 - root - INFO - parsing page 0  of 40
14:42:41 - root - INFO - parsing page 2  of 40
14:42:45 - root - INFO - parsing page 3  of 40
14:42:49 - root - INFO - parsing page 4  of 40
14:42:54 - root - INFO - parsing page 5  of 40
14:42:58 - root - INFO - parsing page 6  of 40
14:43:04 - root - INFO - parsing page 7  of 40
14:43:07 - root - INFO - parsing page 8  of 40
14:43:11 - root - INFO - parsing page 9  of 40
14:43:15 - root - INFO - parsing page 10  of 40
14:43:22 - root - INFO - parsing page 11  of 40
14:43:26 - root - INFO - parsing page 12  of 40
14:43:28 - root - INFO - parsing page 13  of 40
14:43:30 - root - INFO - parsing page 14  of 40
14:43:33 - root - INFO - parsing page 15  of 40
14:43:36 - root - INFO - parsing page 16  of 40
14:43:40 - root - INFO - parsing page 17  of 40
14:43:44 - root - INFO - parsing page 18  of 40
14:43:47 - root - INFO - parsing page 19  of 40
14:43:50 - root - INFO - parsing page 20  of 40
14:43:53 - root - INFO - parsing page 21  of 40
14:43:55 - root - INFO - parsing page 22  of 40
14:43:57 - root - INFO - parsing page 23  of 40
14:44:00 - root - INFO - parsing page 24  of 40
14:44:04 - root - INFO - parsing page 25  of 40
14:44:08 - root - INFO - parsing page 26  of 40
14:44:11 - root - INFO - parsing page 27  of 40
14:44:15 - root - INFO - parsing page 28  of 40
14:44:19 - root - INFO - parsing page 29  of 40
14:44:22 - root - INFO - parsing page 30  of 40
14:44:26 - root - INFO - parsing page 31  of 40
14:44:28 - root - INFO - parsing page 32  of 40
14:44:29 - root - INFO - parsing page 33  of 40
14:44:33 - root - INFO - parsing page 34  of 40
14:44:34 - root - INFO - parsing page 35  of 40
14:44:36 - root - INFO - parsing page 36  of 40
14:44:40 - root - INFO - parsing page 37  of 40
14:44:41 - root - INFO - parsing page 38  of 40
14:44:46 - root - INFO - parsing page 0  of 40
```