### PR TITLE
runAllTests.py runs "correctly" on Windows; pythonapp.yml keeps the pytest log output for examination on merge to base master

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -27,4 +27,5 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest
-        pytest
+        # find and run tests, capturing stdout and stderr for the log
+        pytest --capture=tee-sys

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ nosetests.xml
 /tests/unittest_fotobook.mcf.20210725.pdf
 /Output/cewe2pdfsetup.exe
 /cewe2pdf.iss
+/tests/testClipart/testClipart.mcf.pdf

--- a/cewe2pdf.pyproj
+++ b/cewe2pdf.pyproj
@@ -70,6 +70,7 @@
     <Compile Include="clpFile.py" />
     <Compile Include="passepartout.py" />
     <Compile Include="processManyMcfs.py" />
+    <Compile Include="runAllTests.py" />
     <Compile Include="tests\testClipart\test_drawClipart.py" />
     <Compile Include="tests\testFontDoesNotExist\test_fontDoesNotExist.py" />
     <Compile Include="tests\test_simpleBook.py" />

--- a/cewe2pdf.pyproj
+++ b/cewe2pdf.pyproj
@@ -5,7 +5,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{261b8fb1-634c-480e-b162-8b5b56d18330}</ProjectGuid>
     <ProjectHome />
-    <StartupFile>tests\test_simpleBook.py</StartupFile>
+    <StartupFile>runAllTests.py</StartupFile>
     <SearchPath />
     <WorkingDirectory>.</WorkingDirectory>
     <OutputPath>.</OutputPath>
@@ -23,6 +23,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Content Include=".flake8" />
+    <Content Include=".github\workflows\build_pyinstaller_release.yml" />
+    <Content Include=".github\workflows\pythonapp.yml" />
     <Content Include=".gitignore" />
     <Content Include=".pylintrc" />
     <Content Include="additional_fonts.txt" />
@@ -77,6 +79,8 @@
     <Compile Include="tests\test_webp_loading.py" />
   </ItemGroup>
   <ItemGroup>
+    <Folder Include=".github\" />
+    <Folder Include=".github\workflows\" />
     <Folder Include="tests" />
     <Folder Include="tests\Resources\" />
     <Folder Include="tests\Resources\config\" />

--- a/cewe2pdf.pyproj
+++ b/cewe2pdf.pyproj
@@ -5,7 +5,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{261b8fb1-634c-480e-b162-8b5b56d18330}</ProjectGuid>
     <ProjectHome />
-    <StartupFile>tests\testClipart\test_drawClipart.py</StartupFile>
+    <StartupFile>tests\test_simpleBook.py</StartupFile>
     <SearchPath />
     <WorkingDirectory>.</WorkingDirectory>
     <OutputPath>.</OutputPath>
@@ -45,6 +45,7 @@
     <Content Include="tests\Resources\photofun\decorations\original customClipart1.svg" />
     <Content Include="tests\Resources\photofun\decorations\original customClipart2.svg" />
     <Content Include="tests\Resources\photofun\decorations\rect_cream.svg" />
+    <Content Include="tests\test.webp" />
     <Content Include="tests\testClipart\cewe2pdf.ini" />
     <Content Include="tests\testClipart\testClipart.mcf" />
     <Content Include="tests\testClipart\__pycache__\test_drawClipart.cpython-37-pytest-5.4.1.pyc" />
@@ -72,6 +73,7 @@
     <Compile Include="tests\testClipart\test_drawClipart.py" />
     <Compile Include="tests\testFontDoesNotExist\test_fontDoesNotExist.py" />
     <Compile Include="tests\test_simpleBook.py" />
+    <Compile Include="tests\test_webp_loading.py" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="tests" />

--- a/cewe2pdf.pyproj
+++ b/cewe2pdf.pyproj
@@ -5,13 +5,13 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{261b8fb1-634c-480e-b162-8b5b56d18330}</ProjectGuid>
     <ProjectHome />
-    <StartupFile>tests\test_simpleBook.py</StartupFile>
+    <StartupFile>tests\testClipart\test_drawClipart.py</StartupFile>
     <SearchPath />
     <WorkingDirectory>.</WorkingDirectory>
     <OutputPath>.</OutputPath>
     <ProjectTypeGuids>{888888a0-9f3d-457c-b088-3a5042f75d52}</ProjectTypeGuids>
     <LaunchProvider>Standard Python launcher</LaunchProvider>
-    <InterpreterId>Global|PythonCore|3.7</InterpreterId>
+    <InterpreterId>CondaEnv|CondaEnv|anaconda3</InterpreterId>
     <SuppressConfigureTestFrameworkPrompt>true</SuppressConfigureTestFrameworkPrompt>
     <CommandLineArguments>D:\Users\pete\Source\GitHub\cewe2pdf\tests\unittest_fotobook.mcf</CommandLineArguments>
     <EnableNativeCodeDebugging>False</EnableNativeCodeDebugging>
@@ -23,6 +23,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Content Include=".flake8" />
+    <Content Include=".gitignore" />
     <Content Include=".pylintrc" />
     <Content Include="additional_fonts.txt" />
     <Content Include="build_a_compiled_version.md" />
@@ -33,6 +34,24 @@
     <Content Include="requirements.txt" />
     <Content Include="tests\additional_fonts.txt" />
     <Content Include="tests\cewe2pdf.ini" />
+    <Content Include="tests\Resources\config\keyaccount.xml" />
+    <Content Include="tests\Resources\photofun\backgrounds\201.jpg" />
+    <Content Include="tests\Resources\photofun\backgrounds\448.jpg" />
+    <Content Include="tests\Resources\photofun\decorations\circle.clp" />
+    <Content Include="tests\Resources\photofun\decorations\cliparts_default.xml" />
+    <Content Include="tests\Resources\photofun\decorations\customClipart1.clp" />
+    <Content Include="tests\Resources\photofun\decorations\customClipart2.clp" />
+    <Content Include="tests\Resources\photofun\decorations\original circle.svg" />
+    <Content Include="tests\Resources\photofun\decorations\original customClipart1.svg" />
+    <Content Include="tests\Resources\photofun\decorations\original customClipart2.svg" />
+    <Content Include="tests\Resources\photofun\decorations\rect_cream.svg" />
+    <Content Include="tests\testClipart\cewe2pdf.ini" />
+    <Content Include="tests\testClipart\testClipart.mcf" />
+    <Content Include="tests\testClipart\__pycache__\test_drawClipart.cpython-37-pytest-5.4.1.pyc" />
+    <Content Include="tests\testFontDoesNotExist\additional_fonts.txt" />
+    <Content Include="tests\testFontDoesNotExist\cewe2pdf.ini" />
+    <Content Include="tests\testFontDoesNotExist\testFontDoesNotExist.mcf" />
+    <Content Include="tests\testFontDoesNotExist\__pycache__\test_fontDoesNotExist.cpython-37-pytest-5.4.1.pyc" />
     <Content Include="tests\unittest_fotobook.mcf" />
     <Content Include="tests\unittest_fotobook.mcf.pdf" />
     <Content Include="tests\unittest_fotobook_mcf-Dateien\20200306_111748.jpg" />
@@ -50,10 +69,21 @@
     <Compile Include="clpFile.py" />
     <Compile Include="passepartout.py" />
     <Compile Include="processManyMcfs.py" />
+    <Compile Include="tests\testClipart\test_drawClipart.py" />
+    <Compile Include="tests\testFontDoesNotExist\test_fontDoesNotExist.py" />
     <Compile Include="tests\test_simpleBook.py" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="tests" />
+    <Folder Include="tests\Resources\" />
+    <Folder Include="tests\Resources\config\" />
+    <Folder Include="tests\Resources\photofun\" />
+    <Folder Include="tests\Resources\photofun\backgrounds\" />
+    <Folder Include="tests\Resources\photofun\decorations\" />
+    <Folder Include="tests\testClipart\" />
+    <Folder Include="tests\testClipart\__pycache__\" />
+    <Folder Include="tests\testFontDoesNotExist\" />
+    <Folder Include="tests\testFontDoesNotExist\__pycache__\" />
     <Folder Include="tests\unittest_fotobook_mcf-Dateien" />
   </ItemGroup>
   <ItemGroup>
@@ -74,27 +104,12 @@
 		  https://github.com/microsoft/PTVS/blob/81762d2f2c259b39c46c9ea6d3968c2ec065e370/Python/Product/PythonTools/PythonTools/Project/CustomCommand.cs#L329
 		and I don't believe the code is ever actually used even if the regex locates it!
 		-->
-    <Flake8ErrorRegex>
-      <![CDATA[^(?<filename>.+):(?<line>\d+):(?<column>\d+): (?<message>E\d+ .+)$]]>
-    </Flake8ErrorRegex>
-    <Flake8WarningRegex>
-      <![CDATA[^(?<filename>.+):(?<line>\d+):(?<column>\d+): (?<message>W\d+ .+)$]]>
-    </Flake8WarningRegex>
-    <Flake8MessageRegex>
-      <![CDATA[^(?<filename>.+):(?<line>\d+):(?<column>\d+): (?<message>F\d+ .+)$]]>
-    </Flake8MessageRegex>
+    <Flake8ErrorRegex><![CDATA[^(?<filename>.+):(?<line>\d+):(?<column>\d+): (?<message>E\d+ .+)$]]></Flake8ErrorRegex>
+    <Flake8WarningRegex><![CDATA[^(?<filename>.+):(?<line>\d+):(?<column>\d+): (?<message>W\d+ .+)$]]></Flake8WarningRegex>
+    <Flake8MessageRegex><![CDATA[^(?<filename>.+):(?<line>\d+):(?<column>\d+): (?<message>F\d+ .+)$]]></Flake8MessageRegex>
   </PropertyGroup>
   <Target Name="RunFlake8Command" Label="Run Flake8" Returns="@(Commands)">
-    <CreatePythonCommandItem Target="flake8" 
-    		TargetType="module" 
-		Arguments="" 
-		WorkingDirectory="$(MSBuildProjectDirectory)" 
-		ExecuteIn="output" 
-		RequiredPackages="flake8" 
-		ErrorRegex="$(Flake8ErrorRegex)" 
-		WarningRegex="$(Flake8WarningRegex)" 
-		MessageRegex="$(Flake8MessageRegex)"
-		>
+    <CreatePythonCommandItem Target="flake8" TargetType="module" Arguments="" WorkingDirectory="$(MSBuildProjectDirectory)" ExecuteIn="output" RequiredPackages="flake8" ErrorRegex="$(Flake8ErrorRegex)" WarningRegex="$(Flake8WarningRegex)" MessageRegex="$(Flake8MessageRegex)">
       <Output TaskParameter="Command" ItemName="Commands" />
     </CreatePythonCommandItem>
   </Target>

--- a/runAllTests.py
+++ b/runAllTests.py
@@ -1,2 +1,2 @@
 import pytest
-pytest.main(['-x', '.', ''])
+pytest.main(['-x', '--capture=tee-sys', '.', ''])

--- a/tests/Resources/config/keyaccount.xml
+++ b/tests/Resources/config/keyaccount.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- diese Datei enthaelt die notwendigen konfigurationen des clients -->
+<!-- Haende weg, wenn Sie nicht wissen, was Sie tun! -->
+<!-- Fehlkonfiguration kann dazu fuehren, dass das Programm unerwartetes Verhalten zeigt -->
+
+<config>
+
+	<!-- M K V -->
+<!--
+	<keyAccount>5026</keyAccount>
+	<client id="38" id_win="38" id_mac="37" id_linux="36" />
+	<generic>true</generic>
+-->
+
+	<!-- M K V  alle Produkte-->
+<!--
+	<keyAccount>5026</keyAccount>
+	<client id="38" id_win="38" id_mac="37" id_linux="36" />
+	<generic showPartnerSelectionAtStartup="true">true</generic>
+-->
+
+	<!-- "Normale" Fotowelt -->
+
+	<keyAccount>5026</keyAccount>
+	<client id="38" id_win="38" id_mac="37" id_linux="36" />
+	<generic>false</generic>
+
+
+	<!-- Fotoschau Standalone -->
+<!--
+	<keyAccount>5026</keyAccount>
+	<client id="38" id_win="38" id_mac="37" id_linux="36" />
+	<generic>false</generic>
+-->
+
+	<!-- Anzahl Filialen des Keyaccounts (Für Filialauswahl): one, few, many -->
+	<outlets>many</outlets>
+
+	<!-- Mögliche Bestellwege des Keyaccounts: cd, net or both -->
+	<orderways>BOTH</orderways>
+
+	<!-- Code des Landes, in dem das Programm läuft: Wichtig für Adressfelder -->
+	<country>161</country> <!-- 82 ist deutsch, 224 ist UK -->
+
+	<!-- Sprache der Anwendung (ISO-Code fuer ORDER.TXT) -->
+	<language>no</language>
+
+	<!-- FULL LOCALE z.B. fuer die Erzeugung eines gültigen Ländercodes gegenüber CEWE MYPHOTOS -->
+	<full_locale>no_NO</full_locale>
+</config>


### PR DESCRIPTION
The two test directories _testClipart_ and _testFontDoesNotExist_ are now included in the VS 2019 project and the tests therein will apparently run "correctly" on Windows (though I have no original output with which I could compare my output)
A local keyaccount.xml file is created for use by the two tests above, which otherwise terminate with an exception when run locally on Windows. Oddly, that does not seem to be noticed by the tests in the checkin build?
_test_webp_loading.py_ is included in the VS2019 project and runs correctly on Windows
_runAllTests.py_ is included in the VS2019 project and correctly runs all the same tests as are run by the checkin build and test
Running all the tests, either locally with _runAllTests.py_ or via the checkin build action _pythonapp.yml_, now captures stdout and stderr.