### PR TITLE
Tighten up the initial setup

### DIFF
--- a/tests/testClipart/cewe2pdf.ini
+++ b/tests/testClipart/cewe2pdf.ini
@@ -1,3 +1,4 @@
 [DEFAULT]
 cewe_folder = tests/
+hpsFolder = tests/hps
 extraBackgroundFolders = ../Resources/photofun/backgrounds/201.jpg 

--- a/tests/testFontDoesNotExist/cewe2pdf.ini
+++ b/tests/testFontDoesNotExist/cewe2pdf.ini
@@ -1,3 +1,15 @@
 [DEFAULT]
+# replace the cewe installation program folder so we do not use anything from cewe for this test
+#  (on Windows this folder is normally under %PROGRAMFILES%)
 cewe_folder = tests/
-extraBackgroundFolders = ../Resources/photofun/backgrounds/201.jpg 
+
+# replace the cewe installation data folder so we do not use anything from cewe for this test
+#  (on Windows this folder is normally under %PROGRAMDATA%)
+hpsFolder = tests/hps
+
+# if you wish you can override the keyaccount number in this file, but it should normally be
+# found from a config file under cewe_folder ... Resources/config/keyaccount.xml ... this file
+# being either installed with the cewe program or provided by us as part of the tests structure
+#	keyaccount = 5026
+
+extraBackgroundFolders = ../Resources/photofun/backgrounds/201.jpg


### PR DESCRIPTION
* to make it possible to run tests locally on a developer machine which do not use files from a local CEWE installation or from the keyaccount downloaded material. It is now possible to specify in the .ini file not only the cewe_folder but also the hps folder where the keyaccount data is placed. This allow local testing to match more closely what will happen on the github checkin test run in workflows/pythonapp.yml
* to provide better logging of the initial setup

Also cures the strange difference between the output of testFontDoesNotExist locally and from the workflow - missing initialisation between tests.