### PR TITLE
Added MacOS install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,18 @@ and compiling a pdf document which looks like the cewe photo book.
 
 There are many unsupported options, so an exact conversion cannot be guaranteed. The script is mostly based on reverse-engineering and guessing. It is not meeting any official specifications. So don't be surprised if one or another feature doesn't work. However, improvements are always appreciated.
 
-You will need underlying Cairographics (https://www.cairographics.org/) support installed on your machine for the handling of clip art. How you get this will depend on your platform, but if you have the GTK+ toolkit installed (https://www.gtk.org/docs/installations/) that should do it.
+You will need underlying Cairographics (<https://www.cairographics.org/>) support installed on your machine for the handling of clip art. How you get this will depend on your platform, but if you have the GTK+ toolkit installed (<https://www.gtk.org/docs/installations/>) that should do it.
 
 tags: mcf2pdf, mcf_to_pdf, CEWE Fotobuch als pdf speichern, Fotobuch nach pdf exportieren, cewe Fotobuch pdf, mcf in pdf umwandeln, aus CEW-Fotobuch ein pdf machen, cewe Fotobuch pdf
 
-
 Install - Windows
 -----------------
+
 Download or clone this cewe2pdf repository into a folder of your choice.
 
 The easiest way to start this Python script, is to install the latest python version.
 Then from the start-menu open your pyhthon promt and install the dependencies
+
 ```
 pip install lxml reportlab pillow cairosvg fonttools pyyaml
 ```
@@ -32,35 +33,58 @@ To fix this, you can do the following steps.
 Press Windows Start button and start the "Anaconda prompt"
 
 Make sure you have all the dependencies installed by executing:
+
 ```
 conda install lxml
 conda uninstall reportlab pillow
 pip install reportlab pillow fonttools pyyaml
 ```
+
 There does not appear to be a "binaries only" installation for GTK+ or Cairographics, which means you'll have to build it yourself.
 
 Install - Windows (continued)
 -----------------------------
+
 Go to the directory where cewe2pdf is installed and create a text file there with filename ``cewe_folder.txt``
 and use a text editor to write the installation directory of the CEWE software into the text file.
 Example
 if you have the software branded for the company DM, called "dm-Fotowelt", then the file ``cewe_folder.txt`` should contain:
+
 ```
 C:\Program Files\dm\dm-Fotowelt\dm-Fotowelt.exe
 ```
+
 Save the file and close it.
 
 Alternatively - indeed, preferably, if you want full functionality - you can move on to more extensive configuration by using ``cewe2pdf.ini`` instead of ``cewe_folder.txt``. Here you can specify the location of the cewe folder, provide a comma separated list of locations for additional background images and define how the additional fonts you have specified (see below) are organised into families so that bold and italic texts are shown correctly.
 The contents can, for example, be of the form:
+
 ```
 [DEFAULT]
 cewe_folder = C:\Program Files\Elkjop fotoservice_6.3\elkjop fotoservice
 extraBackgroundFolders =
-	C:/ProgramData/hps/5026/addons/447/backgrounds/v1/backgrounds
-	C:/ProgramData/hps/5026/addons/448/backgrounds/v1/backgrounds
+ C:/ProgramData/hps/5026/addons/447/backgrounds/v1/backgrounds
+ C:/ProgramData/hps/5026/addons/448/backgrounds/v1/backgrounds
 fontFamilies =
-	Bodoni,Bodoni,BodoniB,BodoniI,BodoniBI
+ Bodoni,Bodoni,BodoniB,BodoniI,BodoniBI
 ```
+
+Install - MacOS
+---------------
+
+Download the repository into a folder of your choice.
+
+Install the packages listed in `requirements.txt` into a Python environment.
+
+Install `cairo`, for example using the `brew` package manager. If you dont have `brew`installed, please do so [https://brew.sh/](https://brew.sh/). Then run
+
+```
+brew install cairo
+```
+
+as shown here [https://formulae.brew.sh/formula/cairo](https://formulae.brew.sh/formula/cairo).
+
+Follow the steps outlined for Linux on linking to the software (most likely it will be installed in `/Applications`) and creating the font file. The standard directory for fonts on MacOS is `~/Library/Fonts/`.
 
 Install - Linux
 ---------------
@@ -70,6 +94,7 @@ Copy the script where your album is (`*.mcf` file)
 Ensure the python dependancies are installed.
 
 On Fedora :
+
 ```
 sudo dnf install python2-lxml python2-reportlab cairosvg fonttools pyyaml
 ```
@@ -77,44 +102,55 @@ sudo dnf install python2-lxml python2-reportlab cairosvg fonttools pyyaml
 Define the CEWE path (the directory where your CEWE album software is installed. You can recognize it by the many `.so` files and some subdirs like `Resources`). Put this directory name into a file named `cewe_folder.txt`.
 
 Example with my CEWE FOTOWELT is installed in /home/username/CEWE/CEWE FOTOWELT/ :
+
 ```
 echo "/home/username/CEWE/CEWE FOTOWELT/" > cewe_folder.txt
 ```
 
 Example with my CEWE software in /opt/CEWE :
+
 ```
 echo "/opt/CEWE" > cewe_folder.txt
 ```
 
 Install - additional_fonts.txt
 ------------------------------
+
 Create another text file called ``additional_fonts.txt``.
 This can be left empty, but to get the correct fonts in the pdf you should specify them here.
 
 Add single font files or whole directories with `.ttf` files in it:
 
 Windows font file and directory paths:
+
 ```
 C:\Windows\Fonts\BOD_R.TTF
 C:\Windows\Fonts\
 ```
 
 Example for linux font file and directory paths:
+
 ```
 /usr/share/fonts/truetype/lato/Lato-Heavy.ttf
 /home/myusername/.local/share/fonts/
 ```
 
 This will create an empty file :
+
 ```
 touch additional_fonts.txt
 ```
 
+.xmcf Files
+-----------
+
+If your CEWE software uses `.xmcf` files for your projects, you can simply still use this. The `.xmcf` file format is just an archive of the `*.mcf` file, the `<album>_mcf-Dateien` folder and a few other files. Right click the `.xmcf` file and your os should give you an open to open the archive. Copy the relevant files out of it, and you should be all set for the next steps.
 
 Install - continued
 -------------------
 
 At this point, you should have these files in your current directory :
+
 * `cewe2pdf.py`
 * `cewe_folder.txt`
 * `additional_fonts.txt`
@@ -126,15 +162,18 @@ How to use
 
 Just run `cewe2pdf.py` and you will find a new pdf file to appear in your current directory.
 Example:
+
 ```
    python cewe2pdf.py c:\path\to\my\files\my_nice_fotobook.mcf
 ```
 
 Options
 -------
+
 currently cewe2pdf supports the following options. They are shown if you run
 
-``` python cewe2pdf.py --help```
+```python cewe2pdf.py --help```
+
 ```
 usage: cewe2pdf [-h] [--keepDoublePages] [inputFile]
 
@@ -154,17 +193,20 @@ Example:
 
 ```
 
-
 Development
 -----------
+
 To create a stand-alone compiled package, you can use
+
 ```
 pip install pyinstaller
 pyinstaller cewe2pdf.py --onefile
 ```
 
 To run the unit-test you also need to install
+
 ```
 pip install pytest pdfrw
 ```
+
 You can then call pytest from the working directory or use the runAllTests.py file.


### PR DESCRIPTION
This repository works fine on MacOS, so I added install instructions for it.

Some version of the software uses `xcmf` files and not `cmf` files, so I added a small section to explain the difference and how to use it with `xcmf` files.

Changes in README file:
* macOS install
* using the repo with .xcmf files