### PR TITLE
Handle .mcfx files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ nosetests.xml
 
 /tests/unittest_fotobook.mcf.pdf
 /tests/unittest_fotobook.mcfx.pdf
+/tests/unittest_fotobook.mcf20240410.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ nosetests.xml
 /pageperimage.pdf
 
 /tests/unittest_fotobook.mcf.pdf
+/tests/unittest_fotobook.mcfx.pdf

--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -122,6 +122,14 @@ else:
 
 configlogger = logging.getLogger("cewe2pdf.config")
 
+# make it possible for PIL.Image to open .heic files if the album editor stores them directly
+# ref https://github.com/bash0/cewe2pdf/issues/130
+try:
+    from pillow_heif import register_heif_opener
+    register_heif_opener()
+except Exception as ex:
+    logging.warning("{}: direct use of .heic images is not available".format(ex.msg)) 
+
 # ### settings ####
 image_quality = 86  # 0=worst, 100=best. This is the JPEG quality option.
 image_res = 150  # dpi  The resolution of normal images will be reduced to this value, if it is higher.

--- a/cewe2pdf.pyproj
+++ b/cewe2pdf.pyproj
@@ -86,6 +86,7 @@
   <ItemGroup>
     <Compile Include="cewe2pdf.py" />
     <Compile Include="clpFile.py" />
+    <Compile Include="mcfx.py" />
     <Compile Include="passepartout.py" />
     <Compile Include="processManyMcfs.py" />
     <Compile Include="runAllTests.py" />

--- a/mcfx.py
+++ b/mcfx.py
@@ -1,0 +1,68 @@
+# This file contains code to unpack an .mfcx album to the older format
+# of an mcf file and a folder of images. An mfcx file is just a database
+# with a single table, Files, where each row is a filename and a blob 
+# content for the file. We create a temporary directory and unpack all
+# the files to there. One of these files is the .mcf file in exactly the
+# format which we have used for previous versions.
+
+# This code is basically taken from
+# https://pynative.com/python-sqlite-blob-insert-and-retrieve-digital-data/#h-retrieve-image-and-file-stored-as-a-blob-from-sqlite-table
+
+import logging
+import os
+import tempfile
+import sqlite3
+import sys
+
+from pathlib import Path
+
+def writeTofile(data, filename):
+    # logging.info("Writing {}".format(filename))
+    with open(filename, 'wb') as file:
+        file.write(data)
+    
+def unpackMcfx(mcfxPath: Path):
+    mcfname = ""
+    curdir = os.getcwd();
+    tempdir = tempfile.TemporaryDirectory()
+    try:
+        os.chdir(tempdir.name) # somewhere like C:\Users\pete\AppData\Local\Temp\tmpshi3s9di
+        logging.info("Unpacking mcfx to {}".format(os.getcwd()))
+    
+        fullname = mcfxPath.resolve()
+        connection = sqlite3.connect(fullname)
+        cursor = connection.cursor()
+        logging.info("Connected to mcfx database")
+        
+        sql_fetch_blob_query = """SELECT * from Files"""
+        cursor.execute(sql_fetch_blob_query)
+        record = cursor.fetchall()
+        for row in record:
+            filename = row[0]
+            filecontent = row[1]
+            writeTofile(filecontent, filename)
+            if filename.endswith(".mcf"):
+                if mcfname:
+                    logging.error("Exiting: found more than one mcf file in the mcfx database!")
+                    sys.exit(1)
+                mcfname = Path(tempdir.name) / filename
+            
+        cursor.close()
+    
+    except sqlite3.Error as error:
+        logging.error("Exiting: failure to read image data: {}".format(error))
+        sys.exit(1)
+        
+    finally:
+        if connection:
+            connection.close()
+            logging.info("Disconnected from mcfx database")
+        os.chdir(curdir)
+        
+        if not mcfname:
+            logging.error("Exiting: no mcf file found in mcfx")
+        
+        logging.info("returned to cwd {}, mcfname {}".format(os.getcwd(), mcfname))
+    
+    # return tempdir so that we can use cleanup() when we're done with it
+    return (tempdir, mcfname)

--- a/tests/test_simpleBook.py
+++ b/tests/test_simpleBook.py
@@ -16,8 +16,9 @@ from pdfrw import PdfReader
 from cewe2pdf import convertMcf
 
 def tryToBuildBook(keepDoublePages):
-    inFile = str(Path(Path.cwd(), 'tests', 'unittest_fotobook.mcf'))
-    outFile = str(Path(Path.cwd(), 'tests', 'unittest_fotobook.mcf.pdf'))
+    infilename = 'unittest_fotobook.mcf' # or 'unittest_fotobook.mcfx'
+    inFile = str(Path(Path.cwd(), 'tests', infilename))
+    outFile = str(Path(Path.cwd(), 'tests', infilename + '.pdf'))
     if os.path.exists(outFile) == True:
         os.remove(outFile)
     assert os.path.exists(outFile) == False


### PR DESCRIPTION
If the program is passed a .mcfx file then it creates a temporary directory, unpacks the .mcfx database to that directory, and then processes the .mcf file which it finds there. And then deletes the temporary directory.
Closes #119  
Registers for the direct use of .heic files if the pillow_heif package is installed. Made pillow_heif optional because it does not appear to be necessary on Windows with the 7.3.4 version of the album editor which automatically converts heic to png
Closes #130 