### PR TITLE
A better-than-nothing solution to the problem of .otf font files

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,13 +185,18 @@ usage: cewe2pdf [-h] [--keepDoublePages] [inputFile]
 Convert a foto-book from .mcf file format to .pdf
 
 positional arguments:
-  inputFile          the mcf input file. If not given, the first .mcf in the
+  inputFile          the album input file. If not given, the first .mcf/.mcfx in the
                      current directory is used. (default: None)
 
 optional arguments:
   -h, --help         show this help message and exit
   --keepDoublePages  Each page in the .pdf will be a double-sided page,
                      instead of a normal single page. (default: False)
+  --tmp-dir          A directory for unpacking a .mcfx album. A default temporary
+                     directory is used if none is specified
+  --appdata-dir      A directory for the application to store data which is persistent
+                     between runs, in particular TrueType font files which the program
+                     automatically creates from OpenType font files which it finds.
 
 Example:
    python cewe2pdf.py c:\path\to\my\files\my_nice_fotobook.mcf
@@ -211,7 +216,7 @@ pyinstaller cewe2pdf.py --onefile
 To run the unit-test you also need to install
 
 ```
-pip install pytest pdfrw
+pip install pytest pikepdf
 ```
 
 You can then call pytest from the working directory or use the runAllTests.py file.

--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -71,6 +71,8 @@ from math import sqrt, floor
 
 from pathlib import Path
 
+from os import getenv
+
 from fontTools import ttLib
 
 from mcfx import unpackMcfx
@@ -86,12 +88,12 @@ from reportlab.lib.styles import ParagraphStyle
 
 from lxml import etree
 
+from otf import getTtfsFromOtfs, otf_to_ttf
+
 # import pil and work around a breaking change in pil 10.0.0, see
 #   https://stackoverflow.com/questions/76616042/attributeerror-module-pil-image-has-no-attribute-antialias
 import PIL
 from packaging.version import parse as parse_version
-
-from otf import getTtfsFromOtfs, otf_to_ttf, user_data_dir
 
 if parse_version(PIL.__version__)>=parse_version('9.1.0'):
     pil_antialias = PIL.Image.LANCZOS # closer to the old ANTIALIAS than PIL.Image.Resampling.LANCZOS
@@ -1149,7 +1151,8 @@ def checkCeweFolder(cewe_folder):
     else:
         logging.error("cewe_folder {} not found. This must be a test run which doesn't need it!".format(cewe_folder))
 
-def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=None):
+
+def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=None, appDataDir=None):
     global clipartDict  # pylint: disable=global-statement
     global clipartPathList  # pylint: disable=global-statement
     global fontSubstitutions  # pylint: disable=global-statement
@@ -1327,8 +1330,7 @@ def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=No
             #   see https://github.com/bash0/cewe2pdf/issues/133
             otfFiles = sorted(glob.glob(os.path.join(fontDir, '*.otf')))
             if len(otfFiles) > 0:
-                appdatadir = user_data_dir()
-                ttfsFromOtfs = getTtfsFromOtfs(otfFiles,appdatadir)
+                ttfsFromOtfs = getTtfsFromOtfs(otfFiles,appDataDir)
                 ttfFiles.extend(ttfsFromOtfs)
 
     if len(ttfFiles) > 0:
@@ -1680,6 +1682,9 @@ if __name__ == '__main__':
     parser.add_argument('--tmp-dir', dest='mcfxTmpDir', action='store',
                         default=None,
                         help='Directory for .mcfx file extraction')
+    parser.add_argument('--appdata-dir', dest='appDataDir',
+                        default=None,
+                        help='Directory for persistent app data, eg ttf fonts converted from otf fonts')
     parser.add_argument('inputFile', type=str, nargs='?',
                         help='the mcf input file. If not given, the first .mcf/.mcfx in the current directory is used.')
 
@@ -1722,6 +1727,10 @@ if __name__ == '__main__':
     mcfxTmpDir = None
     if args.mcfxTmpDir is not None:
         mcfxTmpDir = os.path.abspath(args.mcfxTmpDir)
+        
+    appDataDir = None
+    if args.appDataDir is not None:
+        appDataDir = os.path.abspath(args.appDataDir)
 
     # if we have a file name, let's convert it
-    resultFlag = convertMcf(args.inputFile, args.keepDoublePages, pageNumbers, mcfxTmpDir)
+    resultFlag = convertMcf(args.inputFile, args.keepDoublePages, pageNumbers, mcfxTmpDir, appDataDir)

--- a/cewe2pdf.pyproj
+++ b/cewe2pdf.pyproj
@@ -89,6 +89,7 @@
     <Compile Include="mcfx.py" />
     <Compile Include="otf.py" />
     <Compile Include="passepartout.py" />
+    <Compile Include="pathutils.py" />
     <Compile Include="processManyMcfs.py" />
     <Compile Include="runAllTests.py" />
     <Compile Include="tests\testClipart\test_drawClipart.py" />

--- a/cewe2pdf.pyproj
+++ b/cewe2pdf.pyproj
@@ -87,6 +87,7 @@
     <Compile Include="cewe2pdf.py" />
     <Compile Include="clpFile.py" />
     <Compile Include="mcfx.py" />
+    <Compile Include="otf.py" />
     <Compile Include="passepartout.py" />
     <Compile Include="processManyMcfs.py" />
     <Compile Include="runAllTests.py" />

--- a/otf.py
+++ b/otf.py
@@ -1,0 +1,143 @@
+# This file contains code to handle .otf files, which we do by converting to ttf files
+
+# This code is heavily based on https://github.com/awesometoolbox/otf2ttf/blob/master/src/otf2ttf/cli.py
+# and https://github.com/SwagLyrics/SwagLyrics-For-Spotify/blob/master/swaglyrics/__init__.py#L8-L32
+
+import logging
+import os
+import sys
+import tempfile
+
+from pathlib import Path
+from os import getenv
+from cu2qu.pens import Cu2QuPen
+from fontTools.misc.cliTools import makeOutputFileName
+from fontTools.pens.ttGlyphPen import TTGlyphPen
+from fontTools.ttLib import TTFont, newTable
+
+log = logging.getLogger("cewe2pdf.config")
+
+# default approximation error, measured in UPEM
+MAX_ERR = 1.0
+# default 'post' table format
+POST_FORMAT = 2.0
+# assuming the input contours' direction is correctly set (counter-clockwise),
+# we just flip it to clockwise
+REVERSE_DIRECTION = True
+
+def user_data_dir():
+    r"""
+    Get OS specific data directory path for cewe2pdf.
+    Typical user data directories are:
+        macOS:    ~/Library/Application Support/cewe2pdf
+        Unix:     ~/.local/share/cewe2pdf   # or in $XDG_DATA_HOME, if defined
+        Win 10:   C:\Users\<username>\AppData\Local\cewe2pdf
+    :return: full path to the user-specific data dir
+    """
+    # get os specific path
+    if sys.platform.startswith("win"):
+        os_path = getenv("LOCALAPPDATA")
+    elif sys.platform.startswith("darwin"):
+        os_path = "~/Library/Application Support"
+    else:
+        # linux
+        os_path = getenv("XDG_DATA_HOME", "~/.local/share")
+
+    # join with cewe2pdf dir
+    path = Path(os_path) / "cewe2pdf"
+    return path.expanduser()
+
+
+def glyphs_to_quadratic(
+    glyphs, max_err=MAX_ERR, reverse_direction=REVERSE_DIRECTION
+):
+    quadGlyphs = {}
+    for gname in glyphs.keys():
+        glyph = glyphs[gname]
+        ttPen = TTGlyphPen(glyphs)
+        cu2quPen = Cu2QuPen(
+            ttPen, max_err, reverse_direction=reverse_direction
+        )
+        glyph.draw(cu2quPen)
+        quadGlyphs[gname] = ttPen.glyph()
+    return quadGlyphs
+
+
+def otf_to_ttf(ttFont, post_format=POST_FORMAT, **kwargs):
+    assert ttFont.sfntVersion == "OTTO"
+    assert "CFF " in ttFont
+
+    glyphOrder = ttFont.getGlyphOrder()
+
+    ttFont["loca"] = newTable("loca")
+    ttFont["glyf"] = glyf = newTable("glyf")
+    glyf.glyphOrder = glyphOrder
+    glyf.glyphs = glyphs_to_quadratic(ttFont.getGlyphSet(), **kwargs)
+    del ttFont["CFF "]
+    glyf.compile(ttFont)
+
+    ttFont["maxp"] = maxp = newTable("maxp")
+    maxp.tableVersion = 0x00010000
+    maxp.maxZones = 1
+    maxp.maxTwilightPoints = 0
+    maxp.maxStorage = 0
+    maxp.maxFunctionDefs = 0
+    maxp.maxInstructionDefs = 0
+    maxp.maxStackElements = 0
+    maxp.maxSizeOfInstructions = 0
+    maxp.maxComponentElements = max(
+        len(g.components if hasattr(g, "components") else [])
+        for g in glyf.glyphs.values()
+    )
+    maxp.compile(ttFont)
+
+    post = ttFont["post"]
+    post.formatType = post_format
+    post.extraNames = []
+    post.mapping = {}
+    post.glyphOrder = glyphOrder
+    try:
+        post.compile(ttFont)
+    except OverflowError:
+        post.formatType = 3
+        log.warning("Dropping glyph names, they do not fit in 'post' table.")
+
+    ttFont.sfntVersion = "\000\001\000\000"
+
+
+def getTtfsFromOtfs(otfFiles, ttfdirPath = None):
+    resultingTtfFiles = []
+    ttfdir = None
+    if ttfdirPath is not None:
+        if not os.path.exists(ttfdirPath):
+            os.mkdir(ttfdirPath)
+    else:
+        ttfdir = tempfile.TemporaryDirectory()
+        ttfdirPath = ttfdir.name
+
+    for otfFile in otfFiles:
+        if "LiebeGerda-BoldItalic" in otfFile:
+            log.info(f"LiebeGerda-BoldItalic not available: the otf->ttf conversion hangs!")
+            continue # the conversion code hangs on this font!
+        ttfFile = makeOutputFileName(
+            otfFile,
+            outputDir=ttfdirPath,
+            extension=".ttf",
+            overWrite=True, # options.overwrite
+        )
+        if os.path.exists(ttfFile):
+            log.info(f"Accepting otf->ttf font conversion: {ttfFile}")
+        else:
+            log.warning(f"One-time font conversion otf->ttf: {ttfFile}")
+            font = TTFont(otfFile, fontNumber=0) #options.face_index
+            otf_to_ttf(
+                font,
+                post_format=POST_FORMAT, # options.post_format
+                max_err=MAX_ERR, # options.max_error
+                reverse_direction=REVERSE_DIRECTION, # options.reverse_direction
+            )
+            font.save(ttfFile)
+        
+        resultingTtfFiles.append(ttfFile)
+            
+    return resultingTtfFiles

--- a/otf.py
+++ b/otf.py
@@ -9,11 +9,12 @@ import sys
 import tempfile
 
 from pathlib import Path
-from os import getenv
 from cu2qu.pens import Cu2QuPen
 from fontTools.misc.cliTools import makeOutputFileName
 from fontTools.pens.ttGlyphPen import TTGlyphPen
 from fontTools.ttLib import TTFont, newTable
+
+from pathutils import appdata_dir
 
 log = logging.getLogger("cewe2pdf.config")
 
@@ -24,28 +25,6 @@ POST_FORMAT = 2.0
 # assuming the input contours' direction is correctly set (counter-clockwise),
 # we just flip it to clockwise
 REVERSE_DIRECTION = True
-
-def user_data_dir():
-    r"""
-    Get OS specific data directory path for cewe2pdf.
-    Typical user data directories are:
-        macOS:    ~/Library/Application Support/cewe2pdf
-        Unix:     ~/.local/share/cewe2pdf   # or in $XDG_DATA_HOME, if defined
-        Win 10:   C:\Users\<username>\AppData\Local\cewe2pdf
-    :return: full path to the user-specific data dir
-    """
-    # get os specific path
-    if sys.platform.startswith("win"):
-        os_path = getenv("LOCALAPPDATA")
-    elif sys.platform.startswith("darwin"):
-        os_path = "~/Library/Application Support"
-    else:
-        # linux
-        os_path = getenv("XDG_DATA_HOME", "~/.local/share")
-
-    # join with cewe2pdf dir
-    path = Path(os_path) / "cewe2pdf"
-    return path.expanduser()
 
 
 def glyphs_to_quadratic(
@@ -107,13 +86,12 @@ def otf_to_ttf(ttFont, post_format=POST_FORMAT, **kwargs):
 
 def getTtfsFromOtfs(otfFiles, ttfdirPath = None):
     resultingTtfFiles = []
-    ttfdir = None
-    if ttfdirPath is not None:
-        if not os.path.exists(ttfdirPath):
-            os.mkdir(ttfdirPath)
-    else:
-        ttfdir = tempfile.TemporaryDirectory()
-        ttfdirPath = ttfdir.name
+    
+    if ttfdirPath is None:
+        ttfdirPath = appdata_dir()
+        
+    if not os.path.exists(ttfdirPath):
+        os.mkdir(ttfdirPath)
 
     for otfFile in otfFiles:
         if "LiebeGerda-BoldItalic" in otfFile:

--- a/pathutils.py
+++ b/pathutils.py
@@ -1,0 +1,28 @@
+# The beginning of a collection of file system related utilities which do not really
+# belong in the main code file
+
+import sys
+from os import getenv
+from pathlib import Path
+
+def appdata_dir():
+    r"""
+    Get OS specific appdata directory path for cewe2pdf.
+    Typical user data directories are:
+        macOS:    ~/Library/Application Support/cewe2pdf
+        Unix:     ~/.local/share/cewe2pdf   # or in $XDG_DATA_HOME, if defined
+        Win 10:   C:\Users\<username>\AppData\Local\cewe2pdf
+    :return: full path to the user-specific data dir
+    """
+    # get os specific path
+    if sys.platform.startswith("win"):
+        os_path = getenv("LOCALAPPDATA")
+    elif sys.platform.startswith("darwin"):
+        os_path = "~/Library/Application Support"
+    else:
+        # linux
+        os_path = getenv("XDG_DATA_HOME", "~/.local/share")
+
+    # join with cewe2pdf dir
+    path = Path(os_path) / "cewe2pdf"
+    return path.expanduser()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pillow>=5.4.1
 pikepdf>=6.2.9
 pyyaml>=5.3.1
 reportlab>=3.5.23
+cu2qu>=1.6.7

--- a/tests/unittest_fotobook.mcf
+++ b/tests/unittest_fotobook.mcf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fotobook art_id="7250" article_name="CEWE%20FOTOBOK%20Stor%20p%C3%A5%20premium%20matt%20fotopapir" externalProjectId="" folderID="f187e650-9516-4b30-be5b-bfcfeb858699" imagedir="unittest_fotobook_mcf-Dateien" isDataMcf="0" productname="ALB98" startdatecalendarium="" useSpineLogo="0" version="4.0">
+<fotobook art_id="7250" article_name="CEWE%20FOTOBOK%20Stor%20p%C3%A5%20premium%20matt%20fotopapir" externalProjectId="" folderID="4e9d4937-ca3c-4d04-aa26-d52a3b3743a3" imagedir="unittest_fotobook_mcf-Dateien" isDataMcf="0" productname="ALB98" startdatecalendarium="" useSpineLogo="0" version="4.0">
     <project createdWithHPSVersion="7.0.1" createdWithHPSVersionBuild="20191025" projectID="69675965-93ed-4a07-b25f-7dc31eedcc67" projectIDCreatedEpoch="1575196183"/>
-    <savingVersion compatibilityVersion="6.4.2" downCastedByVersion="6.4.7" programversion="7.3.4" programversionBuild="20231122" savetime="2024-04-12 12:23"/>
+    <savingVersion compatibilityVersion="6.4.2" downCastedByVersion="6.4.7" programversion="7.3.4" programversionBuild="20231122" savetime="2024-05-06 16:19"/>
     <articleConfig normalpages="26" pagenaming="1" totalpages="31"/>
     <addOns/>
     <pagenumbering bgcolor="#00000000" fontbold="0" fontfamily="Calibri" fontitalics="0" fontsize="24" format="0" margin="50" position="0" textcolor="#ff000000" textstring="%" verticalMargin="50">
         <outline width="0"/>
     </pagenumbering>
     <extra>
-        <lastTextFormat Alignment="ALIGNLEADING" IndentMargin="5" VerticalIndentMargin="5" backgroundColor="#00000000" font="Calibri,11,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
+        <lastTextFormat Alignment="ALIGNLEADING" IndentMargin="5" VerticalIndentMargin="5" backgroundColor="#00000000" font="CEWE Head,16,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
     </extra>
     <page designStyleID="0" pagenr="0" rotation="0" type="fullcover">
         <bundlesize height="2750" width="4290"/>
@@ -33,7 +33,7 @@
             <position height="106" left="820" rotation="270" top="1322" width="2650" zposition="7000"/>
             <decoration/>
             <text applySpotColor="0" areaTextType="spine"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'Stafford'; font-size:8pt; font-weight:600; font-style:normal; letter-spacing:0px;"><table style="-qt-table-type: root; margin-top:6px; margin-bottom:0px; margin-left:0px; margin-right:0px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-family:'FranklinGothic'; font-size:12pt; color:#df1900;">Front title	</span><span style=" font-size:12pt; font-weight:400; color:#000000;">Amsterdam - Baltimore - Casablanca - Danemark - Edison -<br /></span><span style=" font-family:'FranklinGothic'; font-size:12pt; color:#1b7dd4;">  Subtitle	</span><span style=" font-size:12pt; font-weight:400; color:#000000;">Florida - Gallipoli - Havanna - Italia - Jerusalem</span></p></td></tr></table></body></html>]]><outline width="0"/>
-                <textFormat Alignment="ALIGNVCENTER,ALIGNLEADING" IndentMargin="0" VerticalIndentMargin="0" backgroundColor="#00000000" font="Stafford,8,-1,5,75,0,0,0,0,0" foregroundColor="#ffffffff" hasOutline="0" letterSpacing="0" lineHeight="100"/>
+                <textFormat Alignment="ALIGNLEADING,ALIGNVCENTER" IndentMargin="0" VerticalIndentMargin="0" backgroundColor="#00000000" font="Stafford,8,-1,5,75,0,0,0,0,0" foregroundColor="#ffffffff" hasOutline="0" letterSpacing="0" lineHeight="100"/>
             </text>
         </area>
         <area areatype="textarea">
@@ -240,7 +240,7 @@
                 <border applySpotColor="0" color="#ff000000" enabled="1" gap="10" position="outside" width="5"/>
             </decoration>
             <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'Calibri'; font-size:16pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table style="-qt-table-type: root; margin-top:4px; margin-bottom:0px; margin-left:0px; margin-right:0px;"><tr><td style="border: none;"><p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000000;">kk centred text with border gg</span></p></td></tr></table></body></html>]]><outline color="#ff000000" width="0"/>
-                <textFormat Alignment="ALIGNHCENTER,ALIGNVCENTER" IndentMargin="0" VerticalIndentMargin="50" backgroundColor="#00000000" font="Calibri,16,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
+                <textFormat Alignment="ALIGNVCENTER,ALIGNHCENTER" IndentMargin="0" VerticalIndentMargin="50" backgroundColor="#00000000" font="Calibri,16,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
             </text>
         </area>
         <area areatype="textarea">
@@ -249,7 +249,7 @@
                 <border applySpotColor="0" color="#ff000000" enabled="1" gap="10" position="outside" width="5"/>
             </decoration>
             <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'Calibri'; font-size:16pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table style="-qt-table-type: root; margin-top:21px; margin-bottom:0px; margin-left:0px; margin-right:0px;"><tr><td style="border: none;"><p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000000;">kk centred single text over multiple lines with border gg</span></p></td></tr></table></body></html>]]><outline width="0"/>
-                <textFormat Alignment="ALIGNHCENTER,ALIGNVCENTER" IndentMargin="0" VerticalIndentMargin="50" backgroundColor="#00000000" font="Calibri,16,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
+                <textFormat Alignment="ALIGNVCENTER,ALIGNHCENTER" IndentMargin="0" VerticalIndentMargin="50" backgroundColor="#00000000" font="Calibri,16,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
             </text>
         </area>
         <area areatype="textarea">
@@ -267,7 +267,7 @@
                 <border applySpotColor="0" color="#ff000000" enabled="1" gap="10" position="outside" width="2"/>
             </decoration>
             <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'Calibri'; font-size:10pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table style="-qt-table-type: root; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;"><tr><td style="border: none;"><p align="right" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000000;">A gray image, itself with a blue border, then with added red border to the image in Cewe editor</span></p></td></tr></table></body></html>]]><outline width="0"/>
-                <textFormat Alignment="ALIGNABSOLUTE,ALIGNRIGHT" IndentMargin="0" VerticalIndentMargin="0" backgroundColor="#00000000" font="Calibri,10,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
+                <textFormat Alignment="ALIGNRIGHT,ALIGNABSOLUTE" IndentMargin="0" VerticalIndentMargin="0" backgroundColor="#00000000" font="Calibri,10,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
             </text>
         </area>
         <area areatype="textarea">
@@ -276,7 +276,7 @@
                 <border applySpotColor="0" color="#ff000000" enabled="1" gap="10" position="outside" width="2"/>
             </decoration>
             <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'Calibri'; font-size:10pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table style="-qt-table-type: root; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;"><tr><td style="border: none;"><p align="right" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000000;">A grey image, itself with a blue border, then with added red border to the image in Cewe editor</span></p></td></tr></table></body></html>]]><outline width="0"/>
-                <textFormat Alignment="ALIGNABSOLUTE,ALIGNRIGHT" IndentMargin="0" VerticalIndentMargin="50" backgroundColor="#00000000" font="Calibri,10,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
+                <textFormat Alignment="ALIGNRIGHT,ALIGNABSOLUTE" IndentMargin="0" VerticalIndentMargin="50" backgroundColor="#00000000" font="Calibri,10,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
             </text>
         </area>
         <area areatype="textarea">
@@ -305,7 +305,7 @@
                 <shadow shadowAngle="135" shadowBlurNew="4" shadowDistance="10" shadowEnabled="1" shadowIntensity="51" shadowWidthInMM="1.5"/>
             </decoration>
             <image filename="safecontainer:/20200306_111748.jpg" useABK="1">
-                <cutout left="-0.0140711" scale="0.324043" top="0"/>
+                <cutout left="-0.0148117" scale="0.324043" top="0"/>
             </image>
         </area>
         <area areatype="clipartarea">
@@ -377,7 +377,7 @@
             <designElementIDs passepartout="125186"/>
             <decoration/>
             <image filename="safecontainer:/20200320_124632.jpg" passepartoutDesignElementId="125186" useABK="1">
-                <cutout left="-86.8355" scale="0.169986" top="0"/>
+                <cutout left="-86.8363" scale="0.169986" top="0"/>
                 <ClipartConfiguration applySpotColor="0"/>
             </image>
         </area>
@@ -600,22 +600,57 @@
         <area areatype="textarea">
             <position height="154" left="2446.29" rotation="0" top="1192.9" width="508.535" zposition="7026"/>
             <decoration/>
-            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'Calibri'; font-size:11pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table border="0" style="-qt-table-type: root; margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000000;">A (downloaded) black clipart (clipart=&quot;1134365&quot;) with the colour changed to red #df1900</span></p></td></tr></table></body></html>]]><outline width="0"/>
+            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'Calibri'; font-size:11pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table style="-qt-table-type: root; margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000000;">A (downloaded) black clipart (clipart=&quot;1134365&quot;) with the colour changed to red #df1900</span></p></td></tr></table></body></html>]]><outline width="0"/>
                 <textFormat Alignment="ALIGNLEADING" IndentMargin="5" VerticalIndentMargin="5" backgroundColor="#00000000" font="Calibri,11,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
             </text>
         </area>
         <area areatype="textarea">
             <position height="202" left="2386.29" rotation="0" top="1385.28" width="760.581" zposition="7027"/>
             <decoration/>
-            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'Calibri'; font-size:11pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table border="0" style="-qt-table-type: root; margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000000;">A black clipart (clipart=&quot;129188&quot;) 14466-CLIP-EMBOSS-GD.xml with the colour changed to turquoise #54ddff. Tricky because fill is set to none and stroke is not set</span></p></td></tr></table></body></html>]]><outline width="0"/>
+            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'Calibri'; font-size:11pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table style="-qt-table-type: root; margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000000;">A black clipart (clipart=&quot;129188&quot;) 14466-CLIP-EMBOSS-GD.xml with the colour changed to turquoise #54ddff. Tricky because fill is set to none and stroke is not set</span></p></td></tr></table></body></html>]]><outline width="0"/>
                 <textFormat Alignment="ALIGNLEADING" IndentMargin="5" VerticalIndentMargin="5" backgroundColor="#00000000" font="Calibri,11,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
             </text>
         </area>
         <area areatype="textarea">
             <position height="58" left="2170.54" rotation="0" top="1103.38" width="809" zposition="7028"/>
             <decoration/>
-            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'Calibri'; font-size:11pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table border="0" style="-qt-table-type: root; margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">https://github.com/bash0/cewe2pdf/issues/85</p></td></tr></table></body></html>]]><outline width="0"/>
+            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'Calibri'; font-size:11pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table style="-qt-table-type: root; margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">https://github.com/bash0/cewe2pdf/issues/85</p></td></tr></table></body></html>]]><outline width="0"/>
                 <textFormat Alignment="ALIGNLEADING" IndentMargin="5" VerticalIndentMargin="5" backgroundColor="#00000000" font="Calibri,11,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
+            </text>
+        </area>
+        <area areatype="textarea">
+            <position height="139" left="2167.27" rotation="0" top="1652.12" width="1767" zposition="7029"/>
+            <decoration/>
+            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'FranklinGothic'; font-size:11pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table border="0" style="-qt-table-type: root; margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; line-height:100%;"><span style=" font-weight:600; color:#000000;">The OpenType font .otf file problem: </span><span style=" color:#000000;">CEWE provides some fonts in OpenType files that we cannot handle. We try to fix that with a one-time conversion to ttf files. Here are some tests </span></p><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; line-height:100%;"><span style=" color:#000000;">https://github.com/bash0/cewe2pdf/issues/133</span></p></td></tr></table></body></html>]]><outline width="0"/>
+                <textFormat Alignment="ALIGNLEADING" IndentMargin="5" VerticalIndentMargin="5" backgroundColor="#00000000" font="FranklinGothic,11,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
+            </text>
+        </area>
+        <area areatype="textarea">
+            <position height="103.235" left="2167.27" rotation="0" top="1828.12" width="766.471" zposition="7030"/>
+            <decoration/>
+            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'Arial'; font-size:18pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table border="0" style="-qt-table-type: root; margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; line-height:100%;"><span style=" font-family:'CEWE Head'; font-size:16pt; color:#000000;">CEWE Head</span></p></td></tr></table></body></html>]]><outline width="0"/>
+                <textFormat Alignment="ALIGNLEADING" IndentMargin="5" VerticalIndentMargin="5" backgroundColor="#00000000" font="CEWE Head,16,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
+            </text>
+        </area>
+        <area areatype="textarea">
+            <position height="103.235" left="2167.27" rotation="0" top="1905.85" width="677" zposition="7031"/>
+            <decoration/>
+            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'CEWE Head'; font-size:16pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table border="0" style="-qt-table-type: root; margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; line-height:100%;"><span style=" font-style:italic; color:#000000;">CEWE Head Italic</span></p></td></tr></table></body></html>]]><outline width="0"/>
+                <textFormat Alignment="ALIGNLEADING" IndentMargin="5" VerticalIndentMargin="5" backgroundColor="#00000000" font="CEWE Head,16,-1,5,50,1,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
+            </text>
+        </area>
+        <area areatype="textarea">
+            <position height="103.235" left="2167.27" rotation="0" top="1990.71" width="677" zposition="7032"/>
+            <decoration/>
+            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'CEWE Head'; font-size:16pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table border="0" style="-qt-table-type: root; margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; line-height:100%;"><span style=" font-weight:600; color:#000000;">CEWE Head Bold</span></p></td></tr></table></body></html>]]><outline width="0"/>
+                <textFormat Alignment="ALIGNLEADING" IndentMargin="5" VerticalIndentMargin="5" backgroundColor="#00000000" font="CEWE Head,16,-1,5,75,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
+            </text>
+        </area>
+        <area areatype="textarea">
+            <position height="103.235" left="2167.27" rotation="0" top="2075.56" width="677" zposition="7033"/>
+            <decoration/>
+            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'CEWE Head'; font-size:16pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table border="0" style="-qt-table-type: root; margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; line-height:100%;"><span style=" font-weight:600; font-style:italic; color:#000000;">CEWE Head Bold Italic</span></p></td></tr></table></body></html>]]><outline width="0"/>
+                <textFormat Alignment="ALIGNLEADING" IndentMargin="5" VerticalIndentMargin="5" backgroundColor="#00000000" font="CEWE Head,16,-1,5,75,1,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
             </text>
         </area>
     </page>
@@ -753,17 +788,17 @@
     </page>
     <userfeedback></userfeedback>
     <fotoRelationships>
-        <foto id="safecontainer:/img4.png"/>
-        <foto id="safecontainer:/img6.png"/>
+        <foto id="safecontainer:/img.png"/>
         <foto id="safecontainer:/GreySquareBlueBorder.jpg"/>
-        <foto id="safecontainer:/img3.png"/>
-        <foto id="safecontainer:/img5.png"/>
         <foto id="safecontainer:/img2.png"/>
+        <foto id="safecontainer:/img4.png"/>
         <foto id="file:///D:/Users/pete/Pictures/PhotoAlbumWork/PhotoAlbum2020/Album Candidates/20200306_111748.jpg">
             <foto id="safecontainer:/20200306_111748.jpg" nature="RELATIONSHIP_ONE_TO_ONE_COPY"/>
         </foto>
-        <foto id="safecontainer:/img.png"/>
+        <foto id="safecontainer:/img6.png"/>
+        <foto id="safecontainer:/img5.png"/>
+        <foto id="safecontainer:/img3.png"/>
         <foto id="safecontainer:/20200320_124632.jpg"/>
     </fotoRelationships>
-    <statistics assistantUsed="0" countPauses="62" elapsedTimeGross="2020-04-26T19:39:51" elapsedTimeNet="420134" fotosAdded="9" fotosRemoved="5" pauseTime="344257" sessionsUsed="44"/>
+    <statistics assistantUsed="0" countPauses="62" elapsedTimeGross="2020-04-26T19:39:51" elapsedTimeNet="421117" fotosAdded="9" fotosRemoved="5" pauseTime="344257" sessionsUsed="45"/>
 </fotobook>

--- a/tests/unittest_fotobook_mcf-Dateien/folderid.xml
+++ b/tests/unittest_fotobook_mcf-Dateien/folderid.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<mcfkey folderID="f187e650-9516-4b30-be5b-bfcfeb858699" padding="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"/>
+<mcfkey folderID="4e9d4937-ca3c-4d04-aa26-d52a3b3743a3" padding="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"/>


### PR DESCRIPTION
In particular this will make the CEWE Head font family work.

Will likely close https://github.com/bash0/cewe2pdf/issues/133, though it really annoys me that the otf->ttf conversion hangs on the LiebeGerda-BoldItalic font, so that I have explicitly excluded that. The conversion code is unashamedly copied from [otf2ttf ](https://github.com/awesometoolbox/otf2ttf/blob/master/src/otf2ttf/cli.py). I have no idea how it works, and no real chance of discovering why it hangs.

