### PR TITLE
Tidy up trailing white space in a couple of files

### DIFF
--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -1326,7 +1326,7 @@ def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=No
     if len(fontDirs) > 0:
         for fontDir in fontDirs:
             ttfFiles.extend(sorted(glob.glob(os.path.join(fontDir, '*.ttf'))))
-            # CEWE deliver some fonts as otf, which we cannot use witout first converting to ttf 
+            # CEWE deliver some fonts as otf, which we cannot use witout first converting to ttf
             #   see https://github.com/bash0/cewe2pdf/issues/133
             otfFiles = sorted(glob.glob(os.path.join(fontDir, '*.otf')))
             if len(otfFiles) > 0:
@@ -1727,7 +1727,7 @@ if __name__ == '__main__':
     mcfxTmpDir = None
     if args.mcfxTmpDir is not None:
         mcfxTmpDir = os.path.abspath(args.mcfxTmpDir)
-        
+
     appDataDir = None
     if args.appDataDir is not None:
         appDataDir = os.path.abspath(args.appDataDir)

--- a/mcfx.py
+++ b/mcfx.py
@@ -38,6 +38,7 @@ def unpackMcfx(mcfxPath: Path, tempdirPath):
         logging.info("Unpacking mcfx to {}".format(os.getcwd()))
 
         fullname = mcfxPath.resolve()
+        mcfxMtime = os.path.getmtime(fullname)
         connection = sqlite3.connect(fullname)
         cursor = connection.cursor()
         logging.info("Connected to mcfx database")
@@ -49,6 +50,8 @@ def unpackMcfx(mcfxPath: Path, tempdirPath):
             filename = row[0]
             filecontent = row[1]
             lastchange = row[2] / 1000
+            if lastchange == 0:
+                lastchange = mcfxMtime
             if filename.endswith(".mcf"):
                 if mcfname:
                     logging.error("Exiting: found more than one mcf file in the mcfx database!")

--- a/otf.py
+++ b/otf.py
@@ -86,10 +86,10 @@ def otf_to_ttf(ttFont, post_format=POST_FORMAT, **kwargs):
 
 def getTtfsFromOtfs(otfFiles, ttfdirPath = None):
     resultingTtfFiles = []
-    
+
     if ttfdirPath is None:
         ttfdirPath = appdata_dir()
-        
+
     if not os.path.exists(ttfdirPath):
         os.mkdir(ttfdirPath)
 
@@ -115,7 +115,7 @@ def getTtfsFromOtfs(otfFiles, ttfdirPath = None):
                 reverse_direction=REVERSE_DIRECTION, # options.reverse_direction
             )
             font.save(ttfFile)
-        
+
         resultingTtfFiles.append(ttfFile)
-            
+
     return resultingTtfFiles


### PR DESCRIPTION
To save others cleaning up my Visual Studio created files which have unwanted trailing white space I have started to use a VS extension https://marketplace.visualstudio.com/items?itemName=MadsKristensen.TrailingWhitespaceVisualizer. This checks in a couple of changes made as a result of trying it (at the same time syncing up https://github.com/bash0/cewe2pdf/pull/141 which I had brought in to my otfsupport branch