### PR TITLE
Use fonttools cu2qu instead of old standalone library

### DIFF
--- a/otf.py
+++ b/otf.py
@@ -9,7 +9,7 @@ import sys
 import tempfile
 
 from pathlib import Path
-from cu2qu.pens import Cu2QuPen
+from fontTools.pens.cu2quPen import Cu2QuPen
 from fontTools.misc.cliTools import makeOutputFileName
 from fontTools.pens.ttGlyphPen import TTGlyphPen
 from fontTools.ttLib import TTFont, newTable

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ pillow>=5.4.1
 pikepdf>=6.2.9
 pyyaml>=5.3.1
 reportlab>=3.5.23
-cu2qu>=1.6.7


### PR DESCRIPTION
The standalone cu2qu library is deprecated/archived. https://pypi.org/project/cu2qu/ says
> This library is now maintained as part of
> https://github.com/fonttools/fonttools

Since we already rely on fonttools, we don't even need an additional dependency.

Related: https://github.com/bash0/cewe2pdf/pull/139