### PR TITLE
Do not warn about unchanged colors in cliparts

### DIFF
--- a/clpFile.py
+++ b/clpFile.py
@@ -219,6 +219,10 @@ class ClpFile(object):
         # But parsing svg is a much bigger job!
 
         for curReplacement in colorReplacementList:
+            if curReplacement[0] == curReplacement[1]:
+                # color was not changed
+                continue
+
             # print (curReplacement)
             # Old, simple, but buggy code: self.svgData = self.svgData.replace(oldColorString.encode(encoding="utf-8"),newColorString.encode(encoding="utf-8") )
             # A general replace would look like this:


### PR DESCRIPTION
When colors in cliparts were not changed, cewe2pdf warned about them:
> WARNING:root:Clipart color substitution defined but
> not made from #58676F to #58676F

This is unnecessary since this warning is meant to detect bugs in the color replacement code.

Related: https://github.com/bash0/cewe2pdf/pull/132