### PR TITLE
Clip color substitutions: Handle fill attribute

### DIFF
--- a/clpFile.py
+++ b/clpFile.py
@@ -244,6 +244,15 @@ class ClpFile(object):
                     "(style=\".*?)("+oldColorString+")(.*?\")", r"\1"+newColorString+r"\3", self.svgData.decode(),flags=re.MULTILINE)
                 self.svgData = replacement.encode(encoding="utf-8")
                 subsmade += subcount
+
+            # handle: <path fill="#5E0B23" d="M218.23,..."/>
+            attributes = ("fill")
+            for attribute in attributes:
+                replacement, subcount = re.subn(
+                    attribute+"=\""+curReplacement[0]+"\"", r""+attribute+"=\""+curReplacement[1]+"\"", self.svgData.decode(),flags=re.MULTILINE)
+                self.svgData = replacement.encode(encoding="utf-8")
+                subsmade += subcount
+
             if (subsmade == 0):
                 logging.warning("Clipart color substitution defined but not made from {} to {}".format(curReplacement[0],curReplacement[1]))
         return self


### PR DESCRIPTION
Up to now we only handled colors in `style=""` attributes. This commit adds the standalone `fill="#abcdef"` attribute.

Resolves: https://github.com/bash0/cewe2pdf/issues/151