### PR TITLE
Added .ini options to set image and background resolutions

### DIFF
--- a/cewe2pdf.ini
+++ b/cewe2pdf.ini
@@ -17,3 +17,6 @@
 #	121285, ${PROGRAMDATA}/hps/${KEYACCOUNT}/addons/121285/cliparts/v1/decorations/12089-clip-gold-gd.clp
 
 #passepartoutFolders=${PROGRAMDATA}/hps
+
+#pdfImageResolution = 300
+#pdfBackgroundResolution = 300

--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -136,8 +136,8 @@ except Exception as ex:
 
 # ### settings ####
 image_quality = 86  # 0=worst, 100=best. This is the JPEG quality option.
-image_res = 300  # dpi  The resolution of normal images will be reduced to this value, if it is higher.
-bg_res = 300  # dpi The resolution of background images will be reduced to this value, if it is higher.
+image_res = 150  # dpi  The resolution of normal images will be reduced to this value, if it is higher.
+bg_res = 150  # dpi The resolution of background images will be reduced to this value, if it is higher.
 # ##########
 
 # .mcf units are 0.1 mm
@@ -162,6 +162,21 @@ clipartPathList = tuple()
 passepartoutDict = None    # a dictionary for passepartout  desginElementIDs to file name
 passepartoutFolders = tuple() # global variable with the folders for passepartout frames
 fontSubstitutions = list() # used to avoid repeated messages
+
+
+def getConfigurationInt(configSection, itemName, defaultValue, minimumValue):
+    returnValue = minimumValue
+    try:
+        # eg getConfigurationInt(defaultConfigSection, 'pdfImageResolution', '150', 100)
+        returnValue = int(configSection.get(itemName, defaultValue))
+    except ValueError:
+        logging.error(f'Invalid configuration value supplied for {itemName}')
+        returnValue = int(defaultValue)
+    if returnValue < minimumValue:
+        logging.error(f'Configuration value supplied for {itemName} is less than {minimumValue}, using {minimumValue}')
+        returnValue = minimumValue
+    return returnValue
+
 
 def autorot(im):
     # some cameras return JPEG in MPO container format. Just use the first image.
@@ -1284,6 +1299,12 @@ def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=No
             pptout_filtered1 = list(filter(lambda bg: (len(bg) != 0), pptout_rawFolder)) # filter out empty entries
             pptout_filtered2 = tuple(map(lambda bg: os.path.expandvars(bg), pptout_filtered1)) # expand environment vars pylint: disable=unnecessary-lambda
             passepartoutFolders = pptout_filtered2
+
+            # read resolution options
+            image_res = getConfigurationInt(defaultConfigSection, 'pdfImageResolution', '150', 100)
+            bg_res = getConfigurationInt(defaultConfigSection, 'pdfBackgroundResolution', '150', 100)
+
+        logging.info(f'Using image resolution {image_res}, background resolution {bg_res}')
 
     if keyaccountFolder is not None:
         passepartoutFolders = passepartoutFolders + \

--- a/tests/cewe2pdf.ini
+++ b/tests/cewe2pdf.ini
@@ -1,12 +1,12 @@
 [DEFAULT]
-   # To run with the locally installed cewe system and the franchise extras, comment out the 
+   # To run with the locally installed cewe system and the franchise extras, comment out the
    # two tests/ definitions below and add your own definition, eg
    # cewe_folder = C:\Program Files\Elkjop fotoservice_6.3\elkjop fotoservice
 
 cewe_folder = tests/
    # tests/Resources then contains a small extract of the data files normally found in the actual
    # installed cewe_folder, perhaps C:\Program Files\Elkjop fotoservice_6.3\elkjop fotoservice, just
-   # enough for our tests to produce a halfway decent pdf. 
+   # enough for our tests to produce a halfway decent pdf.
 
 hpsFolder = tests/hps
    # tests/hps/<keyaccount> (where the keyaccount is defined in tests/Resources/config/keyaccount.xml)
@@ -17,12 +17,12 @@ hpsFolder = tests/hps
 #   together with Pete's December 2023 updates for the move from PROGRAMDATA to LOCALAPPDATA
 #fontFamilies =
 #	Bodoni,Bodoni,BodoniB,BodoniI,BodoniBI
-#extraBackgroundFolders = 
+#extraBackgroundFolders =
 #	${PROGRAMDATA}/hps/${KEYACCOUNT}/addons/447/backgrounds/v1/backgrounds
 #	${PROGRAMDATA}/hps/${KEYACCOUNT}/addons/448/backgrounds/v1/backgrounds
 #	Resources/photofun/backgrounds
 #	tests/Resources/photofun/backgrounds
-#extraClipArts = 
+#extraClipArts =
 #	63488, ${LOCALAPPDATA}/CEWE/hps/${KEYACCOUNT}/photofun/decorations/63488/rect_cream/rect_cream.clp
 #	121285, ${LOCALAPPDATA}/CEWE/hps/${KEYACCOUNT}/photofun/decorations/121285/12089-clip-gold-gd/12089-clip-gold-gd.clp
 # or previously:
@@ -33,10 +33,13 @@ hpsFolder = tests/hps
 # There is a problem with the use of CEWE FranklinGothic fonts. For some reason the CEWE FG fonts
 # all have the same full font name (which also happens to be the family name). Furthermore CEWE
 # has not supplied an italic FG font. The code tries to take account of the full font name issue
-# but even so, when the FG fonts and font family are registered with the standard "automatic" 
+# but even so, when the FG fonts and font family are registered with the standard "automatic"
 # registration, the use of FG bold chooses the FG bolditalic font! The problem can be cured by
 # manually declaring a replacement for the missing FG italic, in this case the Windows version
 # of the FG italic font. Don't ask me why, I vaguely suspect the font handling in the reportlab
 # pdf package!
 fontFamilies =
 	FranklinGothic,FranklinGothic,FranklinGothic Medium,Franklin Gothic Book Italic,FranklinGothic Medium Italic
+
+# pdfImageResolution = 300
+# pdfBackgroundResolution = 300


### PR DESCRIPTION
Set the default resolutions back to 150 dpi, but allow options in the .ini file to change these values
```
pdfImageResolution = 300
pdfBackgroundResolution = 300
```
Resolves https://github.com/bash0/cewe2pdf/issues/146