### PR TITLE
First attempt at fixing issue 153

### DIFF
--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -95,6 +95,8 @@ from otf import getTtfsFromOtfs, otf_to_ttf
 import PIL
 from packaging.version import parse as parse_version
 
+from pathutils import localfont_dir
+
 if parse_version(PIL.__version__)>=parse_version('9.1.0'):
     pil_antialias = PIL.Image.LANCZOS # closer to the old ANTIALIAS than PIL.Image.Resampling.LANCZOS
 else:
@@ -143,7 +145,6 @@ bg_res = 150  # dpi The resolution of background images will be reduced to this 
 # .mcf units are 0.1 mm
 # Tabs seem to be in 8mm pitch
 tab_pitch = 80
-line_scale = 1.1
 
 # definitions
 formats = {"ALB82": reportlab.lib.pagesizes.A4,
@@ -466,12 +467,18 @@ def AppendBreak(paragraphText, parachild):
     return paragraphText
 
 
+def lineScaleForFont(font):
+    if font in fontLineScales:
+        return fontLineScales[font]
+    return 1.1
+
+
 def CreateParagraphStyle(backgroundColor, textcolor, font, fontsize):
     parastyle = ParagraphStyle(None, None,
         alignment=reportlab.lib.enums.TA_LEFT,  # will often be overridden
         fontSize=fontsize,
         fontName=font,
-        leading=fontsize*line_scale,  # line spacing (text + leading)
+        leading=fontsize*lineScaleForFont(font),  # line spacing (text + leading)
         borderPadding=0,
         borderWidth=0,
         leftIndent=0,
@@ -727,7 +734,7 @@ def processAreaTextTag(textTag, additional_fonts, area, areaHeight, areaRot, are
                 additional_fonts, bodyfont, bodyfs, bweight, bstyle, backgroundColorAttrib)
             paragraphText += '</para>'
             usefs = maxfs if maxfs > 0 else bodyfs
-            pdf_styleN.leading = usefs * line_scale  # line spacing (text + leading)
+            pdf_styleN.leading = usefs * lineScaleForFont(bodyfont)  # line spacing (text + leading)
             pdf_flowableList.append(Paragraph(paragraphText, pdf_styleN))
 
         else:
@@ -740,7 +747,7 @@ def processAreaTextTag(textTag, additional_fonts, area, areaHeight, areaRot, are
                 paragraphText, maxfs = AppendItemTextInStyle(paragraphText, p.text, p, pdf,
                     additional_fonts, bodyfont, bodyfs, bweight, bstyle, backgroundColorAttrib)
                 usefs = maxfs if maxfs > 0 else bodyfs
-                pdf_styleN.leading = usefs * line_scale  # line spacing (text + leading)
+                pdf_styleN.leading = usefs * lineScaleForFont(bodyfont)  # line spacing (text + leading)
 
             # now run round the htmlspans
             for item in htmlspans:
@@ -750,7 +757,7 @@ def processAreaTextTag(textTag, additional_fonts, area, areaHeight, areaRot, are
                     # but if it is not there then an empty paragraph goes missing :-(
                     paragraphText += '&nbsp;</para>'
                     usefs = maxfs if maxfs > 0 else bodyfs
-                    pdf_styleN.leading = usefs * line_scale  # line spacing (text + leading)
+                    pdf_styleN.leading = usefs * lineScaleForFont(bodyfont)  # line spacing (text + leading)
                     pdf_flowableList.append(Paragraph(paragraphText, pdf_styleN))
                     # start a new pdf para in the style of the para and add the tail text of this br item
                     paragraphText = '<para autoLeading="max">'
@@ -778,7 +785,7 @@ def processAreaTextTag(textTag, additional_fonts, area, areaHeight, areaRot, are
                             # terminate the current pdf para and add it to the flow
                             paragraphText += '</para>'
                             usefs = maxfs if maxfs > 0 else bodyfs
-                            pdf_styleN.leading = usefs * line_scale  # line spacing (text + leading)
+                            pdf_styleN.leading = usefs * lineScaleForFont(bodyfont)  # line spacing (text + leading)
                             pdf_flowableList.append(Paragraph(paragraphText, pdf_styleN))
                             # start a new pdf para in the style of the current span
                             paragraphText = '<para autoLeading="max">'
@@ -798,7 +805,7 @@ def processAreaTextTag(textTag, additional_fonts, area, areaHeight, areaRot, are
             try:
                 paragraphText += '</para>'
                 usefs = maxfs if maxfs > 0 else bodyfs
-                pdf_styleN.leading = usefs * line_scale  # line spacing (text + leading)
+                pdf_styleN.leading = usefs * lineScaleForFont(bodyfont)  # line spacing (text + leading)
                 pdf_flowableList.append(Paragraph(paragraphText, pdf_styleN))
             except Exception as ex:
                 logging.exception('Exception')
@@ -1181,6 +1188,7 @@ def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=No
     global fontSubstitutions  # pylint: disable=global-statement
     global passepartoutDict  # pylint: disable=global-statement
     global passepartoutFolders  # pylint: disable=global-statement
+    global fontLineScales  # pylint: disable=global-statement
 
     clipartDict = dict()    # a dictionary for clipart element IDs to file name
     clipartPathList = tuple()
@@ -1317,10 +1325,17 @@ def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=No
     # Load additional fonts
     ttfFiles = []
     fontDirs = []
+    fontLineScales = {}
     additional_fonts = {}
     additional_fontFamilies = {}
+
     if cewe_folder is not None:
         fontDirs.append(os.path.join(cewe_folder, 'Resources', 'photofun', 'fonts'))
+
+    # if a user has installed fonts locally on his machine, then we need to look there as well
+    localFontFolder = localfont_dir()
+    if os.path.exists(localFontFolder):
+        fontDirs.append(localFontFolder)
 
     try:
         configFontFileName = findFileInDirs('additional_fonts.txt', (albumBaseFolder, os.path.curdir, os.path.dirname(os.path.realpath(__file__))))
@@ -1512,6 +1527,23 @@ def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=No
                 configlogger.info("Registered fontfamily '{}': {}".format(familyName,fontFamily))
             else:
                 configlogger.info("Font family '%s' was already registered from configuration file" % (familyName))
+
+    # Read and record non-standard line scale values for specified fonts
+    if defaultConfigSection is not None:
+        ff = defaultConfigSection.get('fontLineScales', '').splitlines()  # newline separated list of fontname : line_scale
+        specifiedLineScales = filter(lambda bg: (len(bg) != 0), ff)
+        for specifiedLineScale in specifiedLineScales:
+            scaleItems = specifiedLineScale.split(":")
+            if len(scaleItems) == 2:
+                fontName = scaleItems[0].strip()
+                try:
+                    scale = float(scaleItems[1].strip())
+                    fontLineScales[fontName] = scale
+                    configlogger.info(f"Font {fontName} uses non-standard line scale {fontLineScales[fontName]}")
+                except ValueError:
+                    configlogger.error(f"Invalid line scale value {scaleItems[1]} ignored for {fontName}")
+            else:
+                configlogger.error(f"Invalid lineScales entry ignored (should be 'FontName: Scale'): {specifiedLineScale}")
 
     logging.info("Ended font registration")
 

--- a/pathutils.py
+++ b/pathutils.py
@@ -26,3 +26,20 @@ def appdata_dir():
     # join with cewe2pdf dir
     path = Path(os_path) / "cewe2pdf"
     return path.expanduser()
+
+
+def localfont_dir():
+    # Get OS specific directory for locally installed fonts
+    if sys.platform.startswith("win"):
+        # microsoft windows
+        os_path = getenv("LOCALAPPDATA") + "/Microsoft/Windows/Fonts/"
+    elif sys.platform.startswith("darwin"):
+        # Mac and several others
+        os_path = "~/Library/Fonts"
+    else:
+        # assume linux
+        os_path = getenv("XDG_DATA_HOME", "~/.local/share") + "/fonts"
+
+    # join with cewe2pdf dir
+    path = Path(os_path)
+    return path.expanduser()

--- a/tests/cewe2pdf.ini
+++ b/tests/cewe2pdf.ini
@@ -43,3 +43,6 @@ fontFamilies =
 
 # pdfImageResolution = 300
 # pdfBackgroundResolution = 300
+
+fontLineScales =
+	Crafty Girls: 1.43

--- a/tests/unittest_fotobook.mcf
+++ b/tests/unittest_fotobook.mcf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fotobook art_id="7250" article_name="CEWE%20FOTOBOK%20Stor%20p%C3%A5%20premium%20matt%20fotopapir" externalProjectId="" folderID="4e9d4937-ca3c-4d04-aa26-d52a3b3743a3" imagedir="unittest_fotobook_mcf-Dateien" isDataMcf="0" productname="ALB98" startdatecalendarium="" useSpineLogo="0" version="4.0">
+<fotobook art_id="7250" article_name="CEWE%20FOTOBOK%20Stor%20p%C3%A5%20premium%20matt%20fotopapir" externalProjectId="" folderID="9ebd090c-394e-46cf-a38d-922beba2b885" imagedir="unittest_fotobook_mcf-Dateien" isDataMcf="0" productname="ALB98" startdatecalendarium="" useSpineLogo="0" version="4.0">
     <project createdWithHPSVersion="7.0.1" createdWithHPSVersionBuild="20191025" projectID="69675965-93ed-4a07-b25f-7dc31eedcc67" projectIDCreatedEpoch="1575196183"/>
-    <savingVersion compatibilityVersion="6.4.2" downCastedByVersion="6.4.7" programversion="7.3.4" programversionBuild="20231122" savetime="2024-05-06 16:19"/>
+    <savingVersion compatibilityVersion="6.4.2" downCastedByVersion="6.4.7" programversion="7.3.4" programversionBuild="20231122" savetime="2024-06-08 16:47"/>
     <articleConfig normalpages="26" pagenaming="1" totalpages="31"/>
     <addOns/>
     <pagenumbering bgcolor="#00000000" fontbold="0" fontfamily="Calibri" fontitalics="0" fontsize="24" format="0" margin="50" position="0" textcolor="#ff000000" textstring="%" verticalMargin="50">
         <outline width="0"/>
     </pagenumbering>
     <extra>
-        <lastTextFormat Alignment="ALIGNLEADING" IndentMargin="5" VerticalIndentMargin="5" backgroundColor="#00000000" font="CEWE Head,16,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
+        <lastTextFormat Alignment="ALIGNLEADING" IndentMargin="5" VerticalIndentMargin="5" backgroundColor="#00000000" font="Calibri,11,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
     </extra>
     <page designStyleID="0" pagenr="0" rotation="0" type="fullcover">
         <bundlesize height="2750" width="4290"/>
@@ -267,7 +267,7 @@
                 <border applySpotColor="0" color="#ff000000" enabled="1" gap="10" position="outside" width="2"/>
             </decoration>
             <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'Calibri'; font-size:10pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table style="-qt-table-type: root; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;"><tr><td style="border: none;"><p align="right" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000000;">A gray image, itself with a blue border, then with added red border to the image in Cewe editor</span></p></td></tr></table></body></html>]]><outline width="0"/>
-                <textFormat Alignment="ALIGNRIGHT,ALIGNABSOLUTE" IndentMargin="0" VerticalIndentMargin="0" backgroundColor="#00000000" font="Calibri,10,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
+                <textFormat Alignment="ALIGNABSOLUTE,ALIGNTRAILING" IndentMargin="0" VerticalIndentMargin="0" backgroundColor="#00000000" font="Calibri,10,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
             </text>
         </area>
         <area areatype="textarea">
@@ -276,7 +276,7 @@
                 <border applySpotColor="0" color="#ff000000" enabled="1" gap="10" position="outside" width="2"/>
             </decoration>
             <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'Calibri'; font-size:10pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table style="-qt-table-type: root; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;"><tr><td style="border: none;"><p align="right" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000000;">A grey image, itself with a blue border, then with added red border to the image in Cewe editor</span></p></td></tr></table></body></html>]]><outline width="0"/>
-                <textFormat Alignment="ALIGNRIGHT,ALIGNABSOLUTE" IndentMargin="0" VerticalIndentMargin="50" backgroundColor="#00000000" font="Calibri,10,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
+                <textFormat Alignment="ALIGNABSOLUTE,ALIGNTRAILING" IndentMargin="0" VerticalIndentMargin="50" backgroundColor="#00000000" font="Calibri,10,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
             </text>
         </area>
         <area areatype="textarea">
@@ -305,7 +305,7 @@
                 <shadow shadowAngle="135" shadowBlurNew="4" shadowDistance="10" shadowEnabled="1" shadowIntensity="51" shadowWidthInMM="1.5"/>
             </decoration>
             <image filename="safecontainer:/20200306_111748.jpg" useABK="1">
-                <cutout left="-0.0148117" scale="0.324043" top="0"/>
+                <cutout left="-0.0162929" scale="0.324043" top="0"/>
             </image>
         </area>
         <area areatype="clipartarea">
@@ -377,7 +377,7 @@
             <designElementIDs passepartout="125186"/>
             <decoration/>
             <image filename="safecontainer:/20200320_124632.jpg" passepartoutDesignElementId="125186" useABK="1">
-                <cutout left="-86.8363" scale="0.169986" top="0"/>
+                <cutout left="-86.8379" scale="0.169986" top="0"/>
                 <ClipartConfiguration applySpotColor="0"/>
             </image>
         </area>
@@ -621,36 +621,52 @@
         <area areatype="textarea">
             <position height="139" left="2167.27" rotation="0" top="1652.12" width="1767" zposition="7029"/>
             <decoration/>
-            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'FranklinGothic'; font-size:11pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table border="0" style="-qt-table-type: root; margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; line-height:100%;"><span style=" font-weight:600; color:#000000;">The OpenType font .otf file problem: </span><span style=" color:#000000;">CEWE provides some fonts in OpenType files that we cannot handle. We try to fix that with a one-time conversion to ttf files. Here are some tests </span></p><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; line-height:100%;"><span style=" color:#000000;">https://github.com/bash0/cewe2pdf/issues/133</span></p></td></tr></table></body></html>]]><outline width="0"/>
+            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'FranklinGothic'; font-size:11pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table style="-qt-table-type: root; margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; line-height:100%;"><span style=" font-weight:600; color:#000000;">The OpenType font .otf file problem: </span><span style=" color:#000000;">CEWE provides some fonts in OpenType files that we cannot handle. We try to fix that with a one-time conversion to ttf files. Here are some tests </span></p><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; line-height:100%;"><span style=" color:#000000;">https://github.com/bash0/cewe2pdf/issues/133</span></p></td></tr></table></body></html>]]><outline width="0"/>
                 <textFormat Alignment="ALIGNLEADING" IndentMargin="5" VerticalIndentMargin="5" backgroundColor="#00000000" font="FranklinGothic,11,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
             </text>
         </area>
         <area areatype="textarea">
             <position height="103.235" left="2167.27" rotation="0" top="1828.12" width="766.471" zposition="7030"/>
             <decoration/>
-            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'Arial'; font-size:18pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table border="0" style="-qt-table-type: root; margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; line-height:100%;"><span style=" font-family:'CEWE Head'; font-size:16pt; color:#000000;">CEWE Head</span></p></td></tr></table></body></html>]]><outline width="0"/>
+            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'CEWE Head'; font-size:16pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table style="-qt-table-type: root; margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; line-height:100%;"><span style=" color:#000000;">CEWE Head</span></p></td></tr></table></body></html>]]><outline width="0"/>
                 <textFormat Alignment="ALIGNLEADING" IndentMargin="5" VerticalIndentMargin="5" backgroundColor="#00000000" font="CEWE Head,16,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
             </text>
         </area>
         <area areatype="textarea">
             <position height="103.235" left="2167.27" rotation="0" top="1905.85" width="677" zposition="7031"/>
             <decoration/>
-            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'CEWE Head'; font-size:16pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table border="0" style="-qt-table-type: root; margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; line-height:100%;"><span style=" font-style:italic; color:#000000;">CEWE Head Italic</span></p></td></tr></table></body></html>]]><outline width="0"/>
+            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'CEWE Head'; font-size:16pt; font-weight:400; font-style:italic; letter-spacing:0px;"><table style="-qt-table-type: root; margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; line-height:100%;"><span style=" color:#000000;">CEWE Head Italic</span></p></td></tr></table></body></html>]]><outline width="0"/>
                 <textFormat Alignment="ALIGNLEADING" IndentMargin="5" VerticalIndentMargin="5" backgroundColor="#00000000" font="CEWE Head,16,-1,5,50,1,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
             </text>
         </area>
         <area areatype="textarea">
             <position height="103.235" left="2167.27" rotation="0" top="1990.71" width="677" zposition="7032"/>
             <decoration/>
-            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'CEWE Head'; font-size:16pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table border="0" style="-qt-table-type: root; margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; line-height:100%;"><span style=" font-weight:600; color:#000000;">CEWE Head Bold</span></p></td></tr></table></body></html>]]><outline width="0"/>
+            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'CEWE Head'; font-size:16pt; font-weight:600; font-style:normal; letter-spacing:0px;"><table style="-qt-table-type: root; margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; line-height:100%;"><span style=" color:#000000;">CEWE Head Bold</span></p></td></tr></table></body></html>]]><outline width="0"/>
                 <textFormat Alignment="ALIGNLEADING" IndentMargin="5" VerticalIndentMargin="5" backgroundColor="#00000000" font="CEWE Head,16,-1,5,75,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
             </text>
         </area>
         <area areatype="textarea">
             <position height="103.235" left="2167.27" rotation="0" top="2075.56" width="677" zposition="7033"/>
             <decoration/>
-            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'CEWE Head'; font-size:16pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table border="0" style="-qt-table-type: root; margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; line-height:100%;"><span style=" font-weight:600; font-style:italic; color:#000000;">CEWE Head Bold Italic</span></p></td></tr></table></body></html>]]><outline width="0"/>
+            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'CEWE Head'; font-size:16pt; font-weight:600; font-style:italic; letter-spacing:0px;"><table style="-qt-table-type: root; margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; line-height:100%;"><span style=" color:#000000;">CEWE Head Bold Italic</span></p></td></tr></table></body></html>]]><outline width="0"/>
                 <textFormat Alignment="ALIGNLEADING" IndentMargin="5" VerticalIndentMargin="5" backgroundColor="#00000000" font="CEWE Head,16,-1,5,75,1,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
+            </text>
+        </area>
+        <area areatype="textarea">
+            <position height="309" left="2167.27" rotation="0" top="2302.99" width="776.146" zposition="7034"/>
+            <decoration>
+                <border applySpotColor="0" color="#ff000000" enabled="1" gap="10" position="outside" width="2"/>
+            </decoration>
+            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'Crafty Girls'; font-size:12pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table style="-qt-table-type: root; margin-top:2px; margin-bottom:2px; margin-left:2px; margin-right:2px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" color:#000000;">This is the Crafty Girls font, downloaded from fonts.google.com. Does it get the right line spacing?</span></p><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; line-height:100%;"><span style=" color:#000000;">Also when an explicit new line is used?</span></p></td></tr></table></body></html>]]><outline width="0"/>
+                <textFormat Alignment="ALIGNLEADING" IndentMargin="2" VerticalIndentMargin="2" backgroundColor="#00000000" font="Crafty Girls,12,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
+            </text>
+        </area>
+        <area areatype="textarea">
+            <position height="58" left="2167.27" rotation="0" top="2225" width="809" zposition="7035"/>
+            <decoration/>
+            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'Bodoni'; font-size:11pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table border="0" style="-qt-table-type: root; margin-top:5px; margin-bottom:5px; margin-left:5px; margin-right:5px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-family:'Calibri';">https://github.com/bash0/cewe2pdf/issues/153</span></p></td></tr></table></body></html>]]><outline width="0"/>
+                <textFormat Alignment="ALIGNLEADING" IndentMargin="5" VerticalIndentMargin="2" backgroundColor="#00000000" font="Bodoni,11,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" letterSpacing="0" lineHeight="100"/>
             </text>
         </area>
     </page>
@@ -788,17 +804,17 @@
     </page>
     <userfeedback></userfeedback>
     <fotoRelationships>
-        <foto id="safecontainer:/img.png"/>
-        <foto id="safecontainer:/GreySquareBlueBorder.jpg"/>
-        <foto id="safecontainer:/img2.png"/>
-        <foto id="safecontainer:/img4.png"/>
-        <foto id="file:///D:/Users/pete/Pictures/PhotoAlbumWork/PhotoAlbum2020/Album Candidates/20200306_111748.jpg">
-            <foto id="safecontainer:/20200306_111748.jpg" nature="RELATIONSHIP_ONE_TO_ONE_COPY"/>
-        </foto>
         <foto id="safecontainer:/img6.png"/>
         <foto id="safecontainer:/img5.png"/>
         <foto id="safecontainer:/img3.png"/>
+        <foto id="safecontainer:/img4.png"/>
         <foto id="safecontainer:/20200320_124632.jpg"/>
+        <foto id="safecontainer:/img.png"/>
+        <foto id="safecontainer:/img2.png"/>
+        <foto id="file:///D:/Users/pete/Pictures/PhotoAlbumWork/PhotoAlbum2020/Album Candidates/20200306_111748.jpg">
+            <foto id="safecontainer:/20200306_111748.jpg" nature="RELATIONSHIP_ONE_TO_ONE_COPY"/>
+        </foto>
+        <foto id="safecontainer:/GreySquareBlueBorder.jpg"/>
     </fotoRelationships>
-    <statistics assistantUsed="0" countPauses="62" elapsedTimeGross="2020-04-26T19:39:51" elapsedTimeNet="421117" fotosAdded="9" fotosRemoved="5" pauseTime="344257" sessionsUsed="45"/>
+    <statistics assistantUsed="0" countPauses="65" elapsedTimeGross="2020-04-26T19:39:51" elapsedTimeNet="448273" fotosAdded="9" fotosRemoved="5" pauseTime="367933" sessionsUsed="47"/>
 </fotobook>

--- a/tests/unittest_fotobook_mcf-Dateien/folderid.xml
+++ b/tests/unittest_fotobook_mcf-Dateien/folderid.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<mcfkey folderID="4e9d4937-ca3c-4d04-aa26-d52a3b3743a3" padding="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"/>
+<mcfkey folderID="9ebd090c-394e-46cf-a38d-922beba2b885" padding="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"/>


### PR DESCRIPTION
Allows specification of the line scale factor per font that does not want the default value of 1.1 (i.e. 10% of the font size used as leading). 

The entry in cewe2pdf.ini for doing this looks like this:
```
fontLineScales =
	Crafty Girls: 1.43
```

Multiple "font name : scale" lines are possible.

Should be good enough to fix https://github.com/bash0/cewe2pdf/issues/153

