### PR TITLE
Adding logging message counts, first attempt

### DIFF
--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -1670,8 +1670,8 @@ def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=No
         # the expectedLoggingMessageCounts section is one or more newline separated list of
         #   loggername: levelname[count], ...
         # e.g.
-        #   root: CRITICAL[0], ERROR[0], WARNING[4],  INFO[38],  DEBUG[0]
-        # Any loggername that is missing is not checked, any logging level that is missing on a line is not checked
+        #   root: WARNING[4], INFO[38]
+        # Any loggername that is missing is not checked, any logging level that is missing is expected to have 0 messages
         ff = defaultConfigSection.get('expectedLoggingMessageCounts', '').splitlines()
         loggerdefs = filter(lambda bg: (len(bg) != 0), ff)
         for loggerdef in loggerdefs:

--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -128,6 +128,16 @@ else:
 
 configlogger = logging.getLogger("cewe2pdf.config")
 
+# create log output handlers which count messages at each level
+from messageCounterHandler import MsgCounterHandler
+rootMessageCountHandler = MsgCounterHandler()
+rootMessageCountHandler.setLevel(logging.DEBUG) # ensuring that it counts everything
+logging.getLogger().addHandler(rootMessageCountHandler)
+
+configMessageCountHandler = MsgCounterHandler()
+configMessageCountHandler.setLevel(logging.DEBUG) # ensuring that it counts everything
+configlogger.addHandler(configMessageCountHandler)
+
 # make it possible for PIL.Image to open .heic files if the album editor stores them directly
 # ref https://github.com/bash0/cewe2pdf/issues/130
 try:
@@ -1656,6 +1666,11 @@ def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=No
             os.remove(tmpFileName)
     if not unpackedFolder is None:
         unpackedFolder.cleanup()
+
+    # print log count summaries
+    print("Total message counts, including messages suppressed by logger configuration")
+    print(f"Config: {configMessageCountHandler.messageCountText()}")
+    print(f"Root:   {rootMessageCountHandler.messageCountText()}")
 
     return True
 

--- a/cewe2pdf.pyproj
+++ b/cewe2pdf.pyproj
@@ -87,6 +87,7 @@
     <Compile Include="cewe2pdf.py" />
     <Compile Include="clpFile.py" />
     <Compile Include="mcfx.py" />
+    <Compile Include="messageCounterHandler.py" />
     <Compile Include="otf.py" />
     <Compile Include="passepartout.py" />
     <Compile Include="pathutils.py" />

--- a/loggerconfig.yaml
+++ b/loggerconfig.yaml
@@ -4,20 +4,25 @@ formatters:
     format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
     datefmt: '%H:%M:%S'
 handlers:
-  console:
+  consoleEverything:
     class: logging.StreamHandler
     level: DEBUG
     formatter: simple
     stream: ext://sys.stdout
+  consoleWarningOrWorse:
+    class: logging.StreamHandler
+    level: WARNING
+    formatter: simple
+    stream: ext://sys.stdout
 loggers:
   cewe2pdf.config:
-    level: WARNING
-    handlers: [console]
+    handlers: [consoleWarningOrWorse]
+    level: DEBUG
     propagate: no
   PIL.PngImagePlugin:
     level: WARNING
-    handlers: [console]
+    handlers: [consoleEverything]
     propagate: no
 root:
   level: INFO
-  handlers: [console]
+  handlers: [consoleEverything]

--- a/messageCounterHandler.py
+++ b/messageCounterHandler.py
@@ -1,6 +1,7 @@
 # based on Rolf's answer in https://stackoverflow.com/questions/812477/how-many-times-was-logging-error-called
 
 import logging
+import re
 
 class MsgCounterHandler(logging.Handler):
     levelToCountDict = None
@@ -18,9 +19,30 @@ class MsgCounterHandler(logging.Handler):
     def messageCountText(self):
         # create a text with the counts shown in order from worst to best
         text = ""
-        for l in ("ERROR", "WARNING", "INFO", "DEBUG"):
+        for l in (
+            logging.getLevelName(logging.CRITICAL),
+            logging.getLevelName(logging.ERROR),
+            logging.getLevelName(logging.WARNING),
+            logging.getLevelName(logging.INFO),
+            logging.getLevelName(logging.DEBUG)
+            ):
             if (l in self.levelToCountDict):
                 if text: text += ", "
                 text += f"{l}[{self.levelToCountDict[l]}]"
         return text
+
+    def checkCounts(self, loggerName, leveldefs):
+        # leveldefs is a comma separated list of LEVELNAME[count] entries
+        levels = leveldefs.split(",")
+        for level in levels:
+            # parse out the level name and count
+            matches = re.findall("(\w+)\[(\d+)\]",level.strip())
+            if len(matches) == 1:
+                levelname = matches[0][0]
+                levelcount = int(matches[0][1])
+                if levelname in self.levelToCountDict.keys():
+                    actualcount = self.levelToCountDict[levelname]
+                    if actualcount != levelcount:
+                        print(f"NB >>>>> {loggerName} has {actualcount} {levelname} messages, versus expected {levelcount}")
+
 

--- a/messageCounterHandler.py
+++ b/messageCounterHandler.py
@@ -32,17 +32,31 @@ class MsgCounterHandler(logging.Handler):
         return text
 
     def checkCounts(self, loggerName, leveldefs):
-        # leveldefs is a comma separated list of LEVELNAME[count] entries
-        levels = leveldefs.split(",")
-        for level in levels:
+        # leveldefs is a comma separated list of LEVELNAME[count] entries. Use that to create a
+        # dictionary of the expected number of messages at each level. We start with expected 0
+        # for all levels, and then override with the entries from the leveldefs string
+        expected = {logging.CRITICAL: 0, logging.ERROR: 0, logging.WARNING: 0, logging.INFO: 0, logging.DEBUG: 0}
+        levelNamesMapping = logging.getLevelNamesMapping()
+        levelspecs = leveldefs.split(",")
+        for levelspec in levelspecs:
             # parse out the level name and count
-            matches = re.findall("(\w+)\[(\d+)\]",level.strip())
+            matches = re.findall("(\w+)\[(\d+)\]",levelspec.strip())
             if len(matches) == 1:
-                levelname = matches[0][0]
-                levelcount = int(matches[0][1])
-                if levelname in self.levelToCountDict.keys():
-                    actualcount = self.levelToCountDict[levelname]
-                    if actualcount != levelcount:
-                        print(f"NB >>>>> {loggerName} has {actualcount} {levelname} messages, versus expected {levelcount}")
+                levelname = matches[0][0].upper()
+                if levelname in levelNamesMapping.keys():
+                    level = levelNamesMapping[levelname]
+                    levelcount = int(matches[0][1])
+                    expected[level] = levelcount
+                else:
+                    print(f"Unknown message level {levelname} in expected message specification for {loggerName}")
 
-
+        # now run through all the expected counts, including the initial entries with 0 expected which have not
+        # been overridden by the configuration entries and check that the actuals are the same as the expected
+        for level in expected.keys():
+            levelname = logging._levelToName[level]
+            if levelname in self.levelToCountDict.keys():
+                actualcount = self.levelToCountDict[levelname]
+            else:
+                actualcount = 0
+            if actualcount != expected[level]:
+                print(f"NB >>>>> {loggerName} has {actualcount} {levelname} messages, versus expected {expected[level]}")

--- a/messageCounterHandler.py
+++ b/messageCounterHandler.py
@@ -1,0 +1,26 @@
+# based on Rolf's answer in https://stackoverflow.com/questions/812477/how-many-times-was-logging-error-called
+
+import logging
+
+class MsgCounterHandler(logging.Handler):
+    levelToCountDict = None
+
+    def __init__(self, *args, **kwargs):
+        super(MsgCounterHandler, self).__init__(*args, **kwargs)
+        self.levelToCountDict = {}
+
+    def emit(self, record):
+        l = record.levelname
+        if (l not in self.levelToCountDict):
+            self.levelToCountDict[l] = 0
+        self.levelToCountDict[l] += 1
+
+    def messageCountText(self):
+        # create a text with the counts shown in order from worst to best
+        text = ""
+        for l in ("ERROR", "WARNING", "INFO", "DEBUG"):
+            if (l in self.levelToCountDict):
+                if text: text += ", "
+                text += f"{l}[{self.levelToCountDict[l]}]"
+        return text
+

--- a/tests/cewe2pdf.ini
+++ b/tests/cewe2pdf.ini
@@ -46,3 +46,8 @@ fontFamilies =
 
 fontLineScales =
 	Crafty Girls: 1.43
+
+# running the unittest_fotobook on Pete's Windows machine normally creates this many messages
+expectedLoggingMessageCounts =
+	cewe2pdf.config: CRITICAL[0], ERROR[0], WARNING[32], INFO[665], DEBUG[0]
+	root:            CRITICAL[0], ERROR[1], WARNING[4],  INFO[38],  DEBUG[0]

--- a/tests/cewe2pdf.ini
+++ b/tests/cewe2pdf.ini
@@ -49,5 +49,5 @@ fontLineScales =
 
 # running the unittest_fotobook on Pete's Windows machine normally creates this many messages
 expectedLoggingMessageCounts =
-	cewe2pdf.config: CRITICAL[0], ERROR[0], WARNING[32], INFO[665], DEBUG[0]
-	root:            CRITICAL[0], ERROR[1], WARNING[4],  INFO[38],  DEBUG[0]
+	cewe2pdf.config: WARNING[32], INFO[665]
+	root:            ERROR[1], WARNING[4], INFO[38]


### PR DESCRIPTION
Prints a summary count of all the logging messages in the two categories "config" and "root", like this
```
Total message counts, including messages suppressed by logger configuration
Config: WARNING[32], INFO[665]
Root:   ERROR[1], WARNING[4], INFO[38]
```
Should be good enough to fix #147, though I think it might still be a good idea to let clipart have its own logger