### PR TITLE
Check that the fonts in a configured font family have been registered

### DIFF
--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -1514,9 +1514,22 @@ def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=No
                 m_b = members[2].strip()
                 m_i = members[3].strip()
                 m_bi = members[4].strip()
-                pdfmetrics.registerFontFamily(m_familyname, normal=m_n, bold=m_b, italic=m_i, boldItalic=m_bi)
-                explicitlyRegisteredFamilyNames.append(m_familyname)
-                configlogger.warning("Using configured font family '{}': '{}','{}','{}','{}'".format(m_familyname,m_n,m_b,m_i,m_bi))
+                # using font names here which are not already registered as fonts will cause crashes
+                # later, so check for that before registering the family
+                fontsOk = True
+                msg = ""
+                for fontToCheck in (m_n, m_b, m_i, m_bi):
+                    if not fontToCheck in additional_fonts:
+                        if fontsOk:
+                            msg = f"Configured font family {m_familyname} ignored because of unregistered fonts: "
+                        msg += f"{fontToCheck} "
+                        fontsOk = False
+                if not fontsOk:
+                    configlogger.error(msg)
+                else:
+                    pdfmetrics.registerFontFamily(m_familyname, normal=m_n, bold=m_b, italic=m_i, boldItalic=m_bi)
+                    explicitlyRegisteredFamilyNames.append(m_familyname)
+                    configlogger.warning("Using configured font family '{}': '{}','{}','{}','{}'".format(m_familyname,m_n,m_b,m_i,m_bi))
             else:
                 configlogger.error('Invalid FontFamilies line ignored (!= 5 comma-separated strings): ' + explicitFontFamily)
 

--- a/tests/cewe2pdf.ini
+++ b/tests/cewe2pdf.ini
@@ -47,7 +47,8 @@ fontFamilies =
 fontLineScales =
 	Crafty Girls: 1.43
 
-# running the unittest_fotobook on Pete's Windows machine normally creates this many messages
+# Running the unittest_fotobook on Pete's Windows machine normally creates this many messages
+# The two root "expected" errors are xml files which are not legal xml!
 expectedLoggingMessageCounts =
-	cewe2pdf.config: WARNING[32], INFO[665]
-	root:            ERROR[1], WARNING[4], INFO[38]
+	cewe2pdf.config: WARNING[32], INFO[669]
+	root:            ERROR[2], WARNING[4], INFO[38]


### PR DESCRIPTION
... thus avoiding a not so obvious crash at a later time.