### PR TITLE
Change the commit build action on github to use python 3.10.14 (from 3.7)

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -1,6 +1,6 @@
 name: Python application
 
-on: [push]
+on: [push, workflow_dispatch]
 
 jobs:
   build:
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.7
+    - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.10
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.10
+    - name: Set up Python 3.10.14
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10
+        python-version: 3.10.14
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -22,8 +22,8 @@ jobs:
         pip install flake8
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        # exit-zero treats all errors as warnings.
+        flake8 . --count --exit-zero --max-complexity=20 --max-line-length=160 --statistics
     - name: Test with pytest
       run: |
         pip install pytest

--- a/cewe2pdf.ini
+++ b/cewe2pdf.ini
@@ -1,4 +1,4 @@
-# This sample file demonstrates the entries you can in a cewe2pdf.ini file
+# This sample file demonstrates the entries you can use in a cewe2pdf.ini file
 # placed beside your .mcf file (or beside the python script)
 
 [DEFAULT]


### PR DESCRIPTION
- Python 3.10 is well established now, with a "final release" 2023-04-05 and bugfixes only until about Oct 2026, see [here](https://peps.python.org/pep-0619/). We could go to the latest, 3.12, but we can see how this works out.
- I also changed the trigger line for the action to `on: [push, workflow_dispatch]` which means that a build can be manually triggered on github, instead of having to force it to run with some "safe" change, such as changing a text file.
- I have started to use this updated action on my own fork and it seems ok.