### PR TITLE
Fix for incorrect dest variable names in getKeyaccountNumber

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and compiling a pdf document which looks like the cewe photo book.
 
 There are many unsupported options, so an exact conversion cannot be guaranteed. The script is mostly based on reverse-engineering and guessing. It is not meeting any official specifications. So don't be surprised if one or another feature doesn't work. However, improvements are always appreciated.
 
-You will need underlying Cairographics (<https://www.cairographics.org/>) support installed on your machine for the handling of clip art. How you get this will depend on your platform, but if you have the GTK+ toolkit installed (<https://www.gtk.org/docs/installations/>) that should do it. An alternative way to get Cairo installed is to use vcpkg (https://learn.microsoft.com/en-gb/vcpkg/get_started/overview and https://vcpkg.io/en/). For Windows users just seeking a 'cairo.dll' to add to %WINDIR%\System32, take a look at [this project] (https://github.com/preshing/cairo-windows) for binary releases.
+You will need underlying Cairographics (<https://www.cairographics.org/>) support installed on your machine for the handling of clip art. How you get this will depend on your platform, but if you have the GTK+ toolkit installed (<https://www.gtk.org/docs/installations/>) that should do it. An alternative way to get Cairo installed is to use vcpkg (https://learn.microsoft.com/en-gb/vcpkg/get_started/overview and https://vcpkg.io/en/). For Windows users just seeking a 'cairo.dll' to add to %WINDIR%\System32, take a look at [this project](https://github.com/preshing/cairo-windows) for binary releases.
 
 tags: mcf2pdf, mcf_to_pdf, CEWE Fotobuch als pdf speichern, Fotobuch nach pdf exportieren, cewe Fotobuch pdf, mcf in pdf umwandeln, aus CEW-Fotobuch ein pdf machen, cewe Fotobuch pdf
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and compiling a pdf document which looks like the cewe photo book.
 
 There are many unsupported options, so an exact conversion cannot be guaranteed. The script is mostly based on reverse-engineering and guessing. It is not meeting any official specifications. So don't be surprised if one or another feature doesn't work. However, improvements are always appreciated.
 
-You will need underlying Cairographics (<https://www.cairographics.org/>) support installed on your machine for the handling of clip art. How you get this will depend on your platform, but if you have the GTK+ toolkit installed (<https://www.gtk.org/docs/installations/>) that should do it. An alternative way to get Cairo installed is to use vcpkg (https://learn.microsoft.com/en-gb/vcpkg/get_started/overview and https://vcpkg.io/en/)
+You will need underlying Cairographics (<https://www.cairographics.org/>) support installed on your machine for the handling of clip art. How you get this will depend on your platform, but if you have the GTK+ toolkit installed (<https://www.gtk.org/docs/installations/>) that should do it. An alternative way to get Cairo installed is to use vcpkg (https://learn.microsoft.com/en-gb/vcpkg/get_started/overview and https://vcpkg.io/en/). For Windows users just seeking a 'cairo.dll' to add to %WINDIR%\System32, take a look at [this project] (https://github.com/preshing/cairo-windows) for binary releases.
 
 tags: mcf2pdf, mcf_to_pdf, CEWE Fotobuch als pdf speichern, Fotobuch nach pdf exportieren, cewe Fotobuch pdf, mcf in pdf umwandeln, aus CEW-Fotobuch ein pdf machen, cewe Fotobuch pdf
 
@@ -20,7 +20,7 @@ The easiest way to start this Python script, is to install the latest python ver
 Then from the start-menu open your python promt and install the dependencies
 
 ```
-pip install lxml reportlab pillow cairosvg fonttools pyyaml
+pip install packages lxml reportlab pillow pillow_heif cairosvg fonttools pyyaml
 ```
 
 If you have installed the Anaconda Python distribution, there is one catch:

--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -1802,10 +1802,10 @@ if __name__ == '__main__':
     parser.add_argument('--pages', dest='pages', action='store',
                         default=None,
                         help='Page numbers to render, e.g. 1,2,4-9')
-    parser.add_argument('--tmp-dir', dest='mcfxTmpDir', action='store',
+    parser.add_argument('--tmp-dir', dest='mcfxTmp', action='store',
                         default=None,
                         help='Directory for .mcfx file extraction')
-    parser.add_argument('--appdata-dir', dest='appDataDir',
+    parser.add_argument('--appdata-dir', dest='appData',
                         default=None,
                         help='Directory for persistent app data, eg ttf fonts converted from otf fonts')
     parser.add_argument('inputFile', type=str, nargs='?',


### PR DESCRIPTION
Created a fix for incorrect dest variable names in getKeyaccountNumber, otherwise the script won't run.
Optionally updated the README.md with some additional dependencies and added information for cairo binary releases as alternative for windows users.