### PR TITLE
Make sure that pyinstaller can create a working exe from our code.

### DIFF
--- a/cewe2pdf.spec
+++ b/cewe2pdf.spec
@@ -1,9 +1,6 @@
 # -*- mode: python ; coding: utf-8 -*-
 
 
-block_cipher = None
-
-
 a = Analysis(
     ['cewe2pdf.py'],
     pathex=[],
@@ -14,18 +11,15 @@ a = Analysis(
     hooksconfig={},
     runtime_hooks=[],
     excludes=[],
-    win_no_prefer_redirects=False,
-    win_private_assemblies=False,
-    cipher=block_cipher,
     noarchive=False,
+    optimize=0,
 )
-pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+pyz = PYZ(a.pure)
 
 exe = EXE(
     pyz,
     a.scripts,
     a.binaries,
-    a.zipfiles,
     a.datas,
     [],
     name='cewe2pdf',

--- a/otf.py
+++ b/otf.py
@@ -10,7 +10,7 @@ from fontTools.pens.cu2quPen import Cu2QuPen
 from fontTools.misc.cliTools import makeOutputFileName
 from fontTools.pens.ttGlyphPen import TTGlyphPen
 from fontTools.ttLib import TTFont, newTable
-
+from fontTools.cu2qu import errors # not used here, but this makes sure that pyinstaller gets it
 from pathutils import appdata_dir
 
 log = logging.getLogger("cewe2pdf.config")


### PR DESCRIPTION
otf.py now explicitly imports the fontTools.cu2qu.errors module so that it is imported by pyinstaller. Using --hidden-import on the command line or in the spec file would also fix it, but doing this import means that the pyinstaller command remains minimal.