### PR TITLE
Remove match statement, replace with if statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ nosetests.xml
 /tests/unittest_fotobook_mcf-Dateien/folderid.xml
 /tests/unittest_fotobook_mcf-Dateien/identifier.xml
 /tests/testMcfxExtraction/tmp-dir
+/requirements-all.txt

--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -1676,11 +1676,10 @@ def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=No
     if productname in styles:
         productstyle = styles[productname]
     if keepDoublePages:
-        match productstyle:
-            case ProductStyle.AlbumSingleSide:
-                productstyle = ProductStyle.AlbumDoubleSide
-            case ProductStyle.MemoryCard:
-                logging.warning('keepdoublepages option is irrelevant and ignored for a memory card product')
+        if productstyle == ProductStyle.AlbumSingleSide:
+            productstyle = ProductStyle.AlbumDoubleSide
+        elif productstyle == ProductStyle.MemoryCard:
+            logging.warning('keepdoublepages option is irrelevant and ignored for a memory card product')
 
     pdf = canvas.Canvas(outputFileName, pagesize=pagesize)
     pdf.setTitle(albumTitle)

--- a/cewe2pdf.pyproj
+++ b/cewe2pdf.pyproj
@@ -11,8 +11,7 @@
     <OutputPath>.</OutputPath>
     <ProjectTypeGuids>{888888a0-9f3d-457c-b088-3a5042f75d52}</ProjectTypeGuids>
     <LaunchProvider>Standard Python launcher</LaunchProvider>
-    <InterpreterId>
-    </InterpreterId>
+    <InterpreterId>CondaEnv|CondaEnv|cewe2pdf</InterpreterId>
     <SuppressConfigureTestFrameworkPrompt>true</SuppressConfigureTestFrameworkPrompt>
     <CommandLineArguments>D:\Users\pete\Source\GitHub\cewe2pdf\tests\unittest_fotobook.mcf</CommandLineArguments>
     <EnableNativeCodeDebugging>False</EnableNativeCodeDebugging>


### PR DESCRIPTION
So we don't yet require Python 3.10. It's coming, but not right now!
Should close #190, at least as far as the original issue statement is concerned