### PR TITLE
Fixes issue #206, cures text box backgrounds not being coloured over the entire frame area

### DIFF
--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -81,6 +81,7 @@ from pathlib import Path
 
 from fontTools import ttLib
 
+from reportlab.lib.colors import Color
 from reportlab.pdfgen import canvas
 import reportlab.lib.pagesizes
 from reportlab.lib.utils import ImageReader
@@ -98,6 +99,7 @@ from packaging.version import parse as parse_version
 from lxml import etree
 import yaml
 
+from colorFrame import ColorFrame
 from clpFile import ClpFile  # for clipart .CLP and .SVG files
 from mcfx import unpackMcfx
 from messageCounterHandler import MsgCounterHandler
@@ -605,8 +607,8 @@ def CreateParagraphStyle(backgroundColor, textcolor, font, fontsize):
         leftIndent=0,
         rightIndent=0,
         embeddedHyphenation=1,  # allow line break on existing hyphens
-        textColor=textcolor,
-        backColor=backgroundColor)
+        # backColor=backgroundColor, # text bg not used since ColorFrame colours the whole bg
+        textColor=textcolor)
     return parastyle
 
 
@@ -984,13 +986,17 @@ def processAreaTextTag(textTag, additional_fonts, area, areaHeight, areaRot, are
         logging.warning(' Try widening the text box just slightly to avoid an unexpected word wrap, or increasing the height yourself')
         logging.warning(f' Most recent paragraph text: {paragraphText}')
         frameHeight = finalTotalHeight
+    else:
+        frameHeight = max(frameHeight, finalTotalHeight)
+
     frameWidth = max(frameWidth, finalTotalWidth)
 
-    newFrame = Frame(frameBottomLeft_x, frameBottomLeft_y,
+    newFrame = ColorFrame(frameBottomLeft_x, frameBottomLeft_y,
         frameWidth, frameHeight,
         leftPadding=leftPad, bottomPadding=bottomPad,
         rightPadding=rightPad, topPadding=topPad,
-        showBoundary=0  # for debugging useful to set 1
+        showBoundary=0,  # for debugging useful to set 1
+        background=backgroundColor
         )
 
     # This call should produce an exception, if any of the flowables do not fit inside the frame.

--- a/cewe2pdf.pyproj
+++ b/cewe2pdf.pyproj
@@ -123,6 +123,7 @@
   <ItemGroup>
     <Compile Include="cewe2pdf.py" />
     <Compile Include="clpFile.py" />
+    <Compile Include="colorFrame.py" />
     <Compile Include="mcfx.py" />
     <Compile Include="messageCounterHandler.py" />
     <Compile Include="otf.py" />

--- a/colorFrame.py
+++ b/colorFrame.py
@@ -1,0 +1,33 @@
+from reportlab.lib.colors import toColor
+from reportlab.platypus import Frame
+
+# ref https://gist.github.com/styrmis/5317292
+
+class ColorFrame(Frame):
+    """ Extends the reportlab Frame with the ability to draw a background color. """
+
+    def __init__(self, x1, y1, width,height, leftPadding=6, bottomPadding=6,
+            rightPadding=6, topPadding=6, id=None, showBoundary=0,
+            overlapAttachedSpace=None,_debug=None,background=None):
+
+        Frame.__init__(self, x1, y1, width, height, leftPadding,
+            bottomPadding, rightPadding, topPadding, id, showBoundary,
+            overlapAttachedSpace, _debug)
+
+        self.background = background
+
+    def drawBackground(self, canv):
+        color = toColor(self.background)
+
+        canv.saveState()
+        canv.setFillColor(color)
+        canv.rect(
+            self._x1, self._y1, self._x2 - self._x1, self._y2 - self._y1,
+            stroke=0, fill=1
+        )
+        canv.restoreState()
+
+    def addFromList(self, drawlist, canv):
+        if self.background:
+            self.drawBackground(canv)
+        Frame.addFromList(self, drawlist, canv)

--- a/tests/testEmptyPageOne/additional_fonts.txt
+++ b/tests/testEmptyPageOne/additional_fonts.txt
@@ -1,0 +1,1 @@
+c:\windows\fonts\arial.ttf

--- a/tests/testEmptyPageOne/test_emptyPageOne.mcf
+++ b/tests/testEmptyPageOne/test_emptyPageOne.mcf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fotobook art_id="7250" article_name="CEWE%20FOTOBOK%20Stor%20p%C3%A5%20premium%20matt%20fotopapir" externalProjectId="" folderID="7781ac6b-2d16-4790-a24f-46845e3f7b8f" imagedir="test_emptyPageOne_mcf-Dateien" isDataMcf="0" productname="ALB98" startdatecalendarium="" useSpineLogo="0" version="4.0">
-    <project createdWithHPSVersion="7.4.4" createdWithHPSVersionBuild="20240826" multiPurposeText="" projectID="93f22994-3624-4aad-8a1c-7aff1441c69c" projectIDCreatedEpoch="1742371739"/>
-    <savingVersion compatibilityVersion="6.4.2" downCastedByVersion="6.4.7" programversion="7.4.4" programversionBuild="20240826" savetime="2025-03-20 08:36"/>
+<fotobook art_id="7250" article_name="CEWE%20FOTOBOK%20Stor%20p%C3%A5%20premium%20matt%20fotopapir" externalProjectId="" folderID="2a8af9d5-a1cd-4c4e-91b5-8df48e249bf2" imagedir="test_emptyPageOne_mcf-Dateien" isDataMcf="0" productname="ALB98" startdatecalendarium="" useSpineLogo="0" version="4.0">
+    <project createdWithHPSVersion="7.4.4" createdWithHPSVersionBuild="20240826" multiPurposeText="" projectID="93f22994-3624-4aad-8a1c-7aff1441c69c" projectIDCreatedEpoch="1742458603"/>
+    <savingVersion compatibilityVersion="6.4.2" downCastedByVersion="6.4.7" programversion="7.4.4" programversionBuild="20240826" savetime="2025-03-20 20:41"/>
     <articleConfig normalpages="26" pagenaming="1" totalpages="31"/>
     <addOns/>
     <pagenumbering bgcolor="#00000000" fontbold="0" fontfamily="CEWE Head" fontitalics="0" fontsize="24" format="0" margin="50" position="0" textcolor="#ff000000" textstring="%" verticalMargin="50">
         <outline width="0"/>
     </pagenumbering>
     <extra>
-        <lastTextFormat Alignment="ALIGNHCENTER,ALIGNVCENTER" IndentMargin="20" VerticalIndentMargin="20" backgroundColor="#80ffffff" font="CEWE Head,36,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" hyphenation="0" letterSpacing="0" lineHeight="100"/>
+        <lastTextFormat Alignment="ALIGNVCENTER,ALIGNHCENTER" IndentMargin="20" VerticalIndentMargin="20" backgroundColor="#3054ddff" font="Arial,16,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" hyphenation="0" letterSpacing="0" lineHeight="100"/>
         <imageQuality version="1.0.0"/>
     </extra>
     <page designStyleID="1158347" designStyleTemplateName="collage_cover_back" pagenr="0" rotation="0" type="fullcover">
@@ -20,14 +20,14 @@
             <position height="106" left="820" rotation="270" top="1322" width="2650" zposition="7000"/>
             <decoration/>
             <text applySpotColor="0" areaTextType="spine"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'CEWE Head'; font-size:12pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table style="-qt-table-type: root; margin-top:23px; margin-bottom:0px; margin-left:0px; margin-right:0px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; line-height:100%;">Testing empty page one</p></td></tr></table></body></html>]]><outline width="0"/>
-                <textFormat Alignment="ALIGNLEFT,ALIGNVCENTER" IndentMargin="0" VerticalIndentMargin="0" backgroundColor="#00000000" font="CEWE Head,12,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" hyphenation="0" letterSpacing="0" lineHeight="100"/>
+                <textFormat Alignment="ALIGNVCENTER,ALIGNLEFT" IndentMargin="0" VerticalIndentMargin="0" backgroundColor="#00000000" font="CEWE Head,12,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" hyphenation="0" letterSpacing="0" lineHeight="100"/>
             </text>
         </area>
         <area areatype="textarea" backgroundcolor="2164260863">
             <position height="729.616" left="2397.5" rotation="0" top="818.677" width="1692" zposition="7001"/>
             <decoration/>
             <text applySpotColor="1" areaTextType="title"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'CEWE Head'; font-size:36pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table style="-qt-table-type: root; margin-top:275px; margin-bottom:20px; margin-left:20px; margin-right:20px;"><tr><td style="border: none;"><p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; line-height:100%;"><span style=" color:#000000;">Testing empty page one</span></p></td></tr></table></body></html>]]><outline width="0"/>
-                <textFormat Alignment="ALIGNHCENTER,ALIGNVCENTER" IndentMargin="20" VerticalIndentMargin="50" backgroundColor="#80ffffff" font="CEWE Head,36,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" hyphenation="0" letterSpacing="0" lineHeight="100"/>
+                <textFormat Alignment="ALIGNVCENTER,ALIGNHCENTER" IndentMargin="20" VerticalIndentMargin="50" backgroundColor="#80ffffff" font="CEWE Head,36,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" hyphenation="0" letterSpacing="0" lineHeight="100"/>
             </text>
         </area>
     </page>
@@ -60,16 +60,20 @@
         <background designElementId="125061" layout="1" templatename="schema_portrait_011"/>
         <area areatype="textarea" backgroundcolor="810868223">
             <position height="460.297" left="548.577" rotation="0" top="259.002" width="952.845" zposition="7000"/>
-            <decoration/>
-            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'CEWE Head'; font-size:16pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table style="-qt-table-type: root; margin-top:72px; margin-bottom:20px; margin-left:20px; margin-right:20px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; line-height:100%;"><span style=" color:#000000;">The previous page, pagenr == 1, is the first user editable page. In this test it has a black background and no text or picture elements</span></p></td></tr></table></body></html>]]><outline width="0"/>
-                <textFormat Alignment="ALIGNLEFT,ALIGNVCENTER" IndentMargin="20" VerticalIndentMargin="50" backgroundColor="#3054ddff" font="CEWE Head,16,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" hyphenation="0" letterSpacing="0" lineHeight="100"/>
+            <decoration>
+                <border applySpotColor="0" color="#ff000000" enabled="1" gap="10" position="outside" width="2"/>
+            </decoration>
+            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'CEWE Head'; font-size:16pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table style="-qt-table-type: root; margin-top:100px; margin-bottom:20px; margin-left:20px; margin-right:20px;"><tr><td style="border: none;"><p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; line-height:100%;"><span style=" font-family:'Arial'; color:#000000;">The previous page, pagenr == 1, is the first user editable page. In this test it has a black background and no text or picture elements</span></p></td></tr></table></body></html>]]><outline width="0"/>
+                <textFormat Alignment="ALIGNVCENTER,ALIGNLEFT" IndentMargin="20" VerticalIndentMargin="50" backgroundColor="#3054ddff" font="CEWE Head,16,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" hyphenation="0" letterSpacing="0" lineHeight="100"/>
             </text>
         </area>
         <area areatype="textarea" backgroundcolor="810868223">
             <position height="249.238" left="659" rotation="0" top="1225.38" width="732" zposition="7001"/>
-            <decoration/>
-            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'CEWE Head'; font-size:16pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table border="0" style="-qt-table-type: root; margin-top:85px; margin-bottom:20px; margin-left:20px; margin-right:20px;"><tr><td style="border: none;"><p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; line-height:100%;"><span style=" color:#000000;">This is pagenr == 2</span></p></td></tr></table></body></html>]]><outline width="0"/>
-                <textFormat Alignment="ALIGNHCENTER,ALIGNVCENTER" IndentMargin="20" VerticalIndentMargin="50" backgroundColor="#3054ddff" font="CEWE Head,16,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" hyphenation="0" letterSpacing="0" lineHeight="100"/>
+            <decoration>
+                <border applySpotColor="0" color="#ff000000" enabled="1" gap="10" position="outside" width="2"/>
+            </decoration>
+            <text applySpotColor="0" areaTextType="content"><![CDATA[<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"><html><head><meta name="qrichtext" content="1" /><style type="text/css">p, li { white-space: pre-wrap; }</style></head><body style=" font-family:'CEWE Head'; font-size:16pt; font-weight:400; font-style:normal; letter-spacing:0px;"><table style="-qt-table-type: root; margin-top:92px; margin-bottom:20px; margin-left:20px; margin-right:20px;"><tr><td style="border: none;"><p align="center" style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; line-height:100%;"><span style=" font-family:'Arial'; color:#000000;">This is pagenr == 2</span></p></td></tr></table></body></html>]]><outline width="0"/>
+                <textFormat Alignment="ALIGNVCENTER,ALIGNHCENTER" IndentMargin="20" VerticalIndentMargin="50" backgroundColor="#3054ddff" font="CEWE Head,16,-1,5,50,0,0,0,0,0" foregroundColor="#ff000000" hasOutline="0" hyphenation="0" letterSpacing="0" lineHeight="100"/>
             </text>
         </area>
     </page>
@@ -224,5 +228,5 @@
     </page>
     <userfeedback></userfeedback>
     <fotoRelationships/>
-    <statistics assistantUsed="1" countPauses="84" elapsedTimeGross="2020-04-26T19:39:51" elapsedTimeNet="550035" fotosAdded="21" fotosRemoved="18" pauseTime="457871" sessionsUsed="55"/>
+    <statistics assistantUsed="1" countPauses="89" elapsedTimeGross="2020-04-26T19:39:51" elapsedTimeNet="590529" fotosAdded="21" fotosRemoved="18" pauseTime="497774" sessionsUsed="56"/>
 </fotobook>

--- a/tests/testEmptyPageOne/test_emptyPageOne_mcf-Dateien/folderid.xml
+++ b/tests/testEmptyPageOne/test_emptyPageOne_mcf-Dateien/folderid.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<mcfkey folderID="7781ac6b-2d16-4790-a24f-46845e3f7b8f" padding="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"/>
+<mcfkey folderID="2a8af9d5-a1cd-4c4e-91b5-8df48e249bf2" padding="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"/>


### PR DESCRIPTION
Here are the new screenshots for the images from #206, first from the cewe editor
![Screenshot 2025-03-20 225336](https://github.com/user-attachments/assets/c38f3447-ff1a-4bbd-b13e-d6165141426f)
and then from our pdf
![Screenshot 2025-03-20 225412](https://github.com/user-attachments/assets/6e9ebaf5-3fcd-4947-a9e1-479fa539afc0)
This also fixes an unreported bug which has been visible on page 4 of the unittest_fotobook ever since I joined the project, where the text boxes showing all the Bodoni variations have never had the correct size. The solution was to color the frame containing the text rather than using the background color of the text itself. 