### PR TITLE
Next refactoring, taking out more to cewIinfo, clipArt and a new imageUtils

### DIFF
--- a/cewe2pdf.pyproj
+++ b/cewe2pdf.pyproj
@@ -152,6 +152,9 @@
     <Compile Include="extraLoggers.py">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="imageUtils.py">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="lineScales.py">
       <SubType>Code</SubType>
     </Compile>

--- a/ceweInfo.py
+++ b/ceweInfo.py
@@ -3,10 +3,58 @@ import logging
 import os.path
 import os
 import sys
+from enum import Enum
+
+import reportlab.lib
 
 from lxml import etree
-
 from extraLoggers import mustsee
+
+
+class ProductStyle(Enum):
+    AlbumSingleSide = 1  # normal for albums, we divide the cewe 2 page bundle to single pages
+    AlbumDoubleSide = 2  # any album when --keepdoublepages is set
+    MemoryCard = 3 # memory card game
+
+
+class AlbumInfo():
+    def __init__(self):
+        return
+
+    # page sizes for various products. Probably not important since the bundlesize element
+    # is used to set the page sizes along the way
+    formats = {
+        "ALB82": reportlab.lib.pagesizes.A4,
+        "ALB98": reportlab.lib.pagesizes.A4, # unittest, L 20.5cm x 27.0cm
+        "ALB32": (300 * reportlab.lib.pagesizes.mm, 300 * reportlab.lib.pagesizes.mm), # album XL, 30 x 30 cm
+        "ALB17": (205 * reportlab.lib.pagesizes.mm, 205 * reportlab.lib.pagesizes.mm), # album kvadratisk, 20.5 x 20.5 cm
+        "ALB69": (5400/100/2*reportlab.lib.units.cm, 3560/100*reportlab.lib.units.cm),
+        # add other page sizes here
+        "MEM3": (300 * reportlab.lib.pagesizes.mm, 300 * reportlab.lib.pagesizes.mm) # memory game cards 6x6cm
+        }
+
+    # product style. The CEWE album products (which is what we are normally expecting in this
+    # code) are basically defined in two page bundles. We normally will want single side pdfs
+    # so we let the style default to ProductStyle.AlbumSingleSide unless the product is found
+    # in this table. If we want to keep the double side layout in the pdf, then the keepDoublePages
+    # option will cause AlbumSingleSide to be changed to AlbumDoubleSide.
+    # Other "non-album" styles which we handle appear in this table
+    styles = {
+        "MEM3": ProductStyle.MemoryCard # memory game cards 6x6cm
+        }
+
+    @staticmethod
+    def isAlbumProduct(ps: ProductStyle):
+        return ps in (ProductStyle.AlbumSingleSide, ProductStyle.AlbumDoubleSide)
+
+    @staticmethod
+    def isAlbumSingleSide(ps: ProductStyle):
+        return ps == ProductStyle.AlbumSingleSide
+
+    @staticmethod
+    def isAlbumDoubleSide(ps: ProductStyle):
+        return ps == ProductStyle.AlbumDoubleSide
+
 
 class CeweInfo():
     def __init__(self):

--- a/clipArt.py
+++ b/clipArt.py
@@ -1,10 +1,14 @@
+import glob
 import logging
 import os.path
 import os
 
 from pathlib import Path
+from lxml import etree
 
+from ceweInfo import CeweInfo
 from clpFile import ClpFile  # for clipart .CLP and .SVG files
+from extraLoggers import configlogger
 from pathutils import findFileInDirs
 
 
@@ -61,3 +65,76 @@ def getClipConfig(Element):
             if mirror in ('x', 'both'):
                 flipY = True
     return colorreplacements, flipX, flipY
+
+
+def readClipArtConfigXML(baseFolder, keyaccountFolder, clipartDict):
+    """Parse the configuration XML file and generate a dictionary of designElementId to fileName
+    currently only cliparts_default.xml is supported !"""
+    clipartPathList = CeweInfo.getBaseClipartLocations(baseFolder) # append instead of overwrite global variable
+    xmlConfigFileName = 'cliparts_default.xml'
+    try:
+        xmlFileName = findFileInDirs(xmlConfigFileName, clipartPathList)
+        loadClipartConfigXML(xmlFileName, clipartDict)
+        configlogger.info(f'{xmlFileName} listed {len(clipartDict)} cliparts')
+    except: # noqa: E722 # pylint: disable=bare-except
+        configlogger.info(f'Could not locate and load the clipart definition file: {xmlConfigFileName}')
+        configlogger.info('Trying a search for cliparts instead')
+        # cliparts_default.xml went missing in 7.3.4 so we have to go looking for all the individual xml
+        # files, which still seem to be there and have the same format as cliparts_default.xml, and see
+        # if we can build our internal dictionary from them.
+        decorations = CeweInfo.getCeweDecorationsFolder(baseFolder)
+        configlogger.info(f'clipart xml path: {decorations}')
+        for (root, dirs, files) in os.walk(decorations): # walk returns a 3-tuple so pylint: disable=unused-variable
+            for decorationfile in files:
+                if decorationfile.endswith(".xml"):
+                    loadClipartConfigXML(os.path.join(root, decorationfile), clipartDict)
+        numberClipartsLocated = len(clipartDict)
+        if numberClipartsLocated > 0:
+            configlogger.info(f'{numberClipartsLocated} clipart xmls found')
+        else:
+            configlogger.error('No clipart xmls found, no delivered cliparts will be available.')
+
+    if keyaccountFolder is None:
+        # In "production" this is definitely an error, although for unit tests (in particular when
+        # run on the checkin build where CEWE is not installed and there is definitely no downloaded
+        # stuff from the installation) it isn't really an error because there is a local folder
+        # tests/Resources/photofun/decorations with the clipart files needed for the tests.
+        configlogger.error("No downloaded clipart folder found")
+        return clipartPathList
+
+    # from (at least) 7.3.4 the addon cliparts might be in more than one structure, so ... first the older layout
+    addonclipartxmls = os.path.join(keyaccountFolder, "addons", "*", "cliparts", "v1", "decorations", "*.xml")
+    for file in glob.glob(addonclipartxmls):
+        loadClipartConfigXML(file, clipartDict)
+
+    # then the newer layout
+    currentClipartCount = len(clipartDict)
+    localDecorations = os.path.join(keyaccountFolder, 'photofun', 'decorations')
+    xmlfiles = glob.glob(os.path.join(localDecorations, "*", "*", "*.xml"))
+    configlogger.info(f'local clipart xml path: {localDecorations}')
+    for xmlfile in xmlfiles:
+        loadClipartConfigXML(xmlfile, clipartDict)
+    numberClipartsLocated = len(clipartDict) - currentClipartCount
+    if numberClipartsLocated > 0:
+        configlogger.info(f'{numberClipartsLocated} local clipart xmls found')
+
+    if len(clipartDict) == 0:
+        configlogger.error('No cliparts found')
+
+    return clipartPathList
+
+
+def loadClipartConfigXML(xmlFileName, clipartDict):
+    try:
+        with open(xmlFileName, 'rb') as clipArtXml:
+            xmlInfo = etree.parse(clipArtXml)
+        for decoration in xmlInfo.findall('decoration'):
+            clipartElement = decoration.find('clipart')
+            # we might be reading a decoration definition that is not clipart, just ignore those
+            if clipartElement is None:
+                continue
+            fileName = os.path.join(os.path.dirname(xmlFileName), clipartElement.get('file'))
+            designElementId = int(clipartElement.get('designElementId'))    # assume these IDs are always integers.
+            clipartDict[designElementId] = fileName
+    except Exception as clpOpenEx: # pylint: disable=broad-exception-caught
+        logging.error(f"Cannot open clipart file {xmlFileName}: {repr(clpOpenEx)}")

--- a/imageUtils.py
+++ b/imageUtils.py
@@ -1,0 +1,29 @@
+import PIL
+
+
+def autorot(im):
+    # some cameras return JPEG in MPO container format. Just use the first image.
+    if im.format not in ('JPEG', 'MPO'):
+        return im
+    ExifRotationTag = 274
+    exifdict = im.getexif()
+    if exifdict is not None and ExifRotationTag in list(exifdict.keys()):
+        orientation = exifdict[ExifRotationTag]
+        # The PIL.Image values must be dynamic in some way so disable pylint no-member
+        if orientation == 2:
+            im = im.transpose(PIL.Image.FLIP_LEFT_RIGHT) # pylint: disable=no-member
+        elif orientation == 3:
+            im = im.transpose(PIL.Image.ROTATE_180) # pylint: disable=no-member
+        elif orientation == 4:
+            im = im.transpose(PIL.Image.FLIP_TOP_BOTTOM) # pylint: disable=no-member
+        elif orientation == 5:
+            im = im.transpose(PIL.Image.FLIP_TOP_BOTTOM) # pylint: disable=no-member
+            im = im.transpose(PIL.Image.ROTATE_90) # pylint: disable=no-member
+        elif orientation == 6:
+            im = im.transpose(PIL.Image.ROTATE_270) # pylint: disable=no-member
+        elif orientation == 7:
+            im = im.transpose(PIL.Image.FLIP_LEFT_RIGHT) # pylint: disable=no-member
+            im = im.transpose(PIL.Image.ROTATE_90) # pylint: disable=no-member
+        elif orientation == 8:
+            im = im.transpose(PIL.Image.ROTATE_90) # pylint: disable=no-member
+    return im


### PR DESCRIPTION
This is probably enough "file structure" refactoring, that is splitting of cewe2pdf.py into several files. Now the main file is primariy concerned with the process of breaking down the mcf into processable chunks and doing that, while the underlying detail operations are placed out of the way of the main flow. At over 1000 lines it's still a big file, but good enough for now.