### PR TITLE
Refactor conversion-specific state out of module globals

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,7 +560,7 @@ Tests using compare-pdf originally used the modification time to sort result pdf
 ### Cleaning up temporary files 
 Running tests during development can leave temporary output files lying around. Cleaning these away is a bit tricky, because it's important not to delete the approved result pdfs. On Windows you can locate these files with a powershell command like this:
 ```
-$pattern = '^(test|unittest)[A-Za-z0-9._-]*\.mcf\.\d{8}[DS]\.(pdf|idx\.png)$'
+$pattern = '^(test|unittest|allblack)[A-Za-z0-9._-]*\.mcf\.\d{8}[DS]\.(pdf|idx\.png)$'
 Get-ChildItem -Recurse -File |
 Where-Object {
     $_.FullName -notmatch '\\previous_result_pdfs\\' -and

--- a/albumIndex.py
+++ b/albumIndex.py
@@ -10,7 +10,7 @@ from PIL import Image
 
 from configUtils import getConfigurationBool, getConfigurationFloat, getConfigurationInt
 
-class Index(): # pylint: disable=too-many-instance-attributes
+class AlbumIndex(): # pylint: disable=too-many-instance-attributes
 
     def __init__(self, configSection):
         self.indexEntries = {}
@@ -116,7 +116,7 @@ class Index(): # pylint: disable=too-many-instance-attributes
         if not self.indexing:
             return None
         # Initialize a pdf canvas for the index
-        indexFileName = Index.GetIndexName(outputFileName)
+        indexFileName = AlbumIndex.GetIndexName(outputFileName)
         pdf = canvas.Canvas(indexFileName, pagesize=pagesize)
         pdf.setTitle(albumTitle + " index")
         # Create the pdf page containing the index
@@ -131,11 +131,11 @@ class Index(): # pylint: disable=too-many-instance-attributes
         if not self.indexing:
             return None
         doc = pymupdf.open(indexPdfFileName)
-        image = Index._convert_to_opencv(doc.load_page(0), dpi=150)
-        transparent_image = Index._make_white_transparent(image)
+        image = AlbumIndex._convert_to_opencv(doc.load_page(0), dpi=150)
+        transparent_image = AlbumIndex._make_white_transparent(image)
 
         # I used to crop the image to reduce the size of the final png image
-        #   cropped_image = Index._crop_transparent_borders(transparent_image)
+        #   cropped_image = AlbumIndex._crop_transparent_borders(transparent_image)
         # but the effect was that indexes in different albums were scaled differently,
         # making it impossible to have consistent font size and margin sizes in the
         # various .ini files and get the same resulting text sizes on the merged index page.

--- a/backgrounds.py
+++ b/backgrounds.py
@@ -12,12 +12,13 @@ from reportlab.lib.utils import ImageReader
 
 from ceweInfo import AlbumInfo
 from configUtils import getConfigurationBool
+from conversionState import ConversionState
 from pathutils import findFileInDirs
 from pageTypes import PageProcessingType
 from renderContext import RenderContext
 
 
-def processBackground(backgroundTags, bg_notFoundDirList, cewe_folder, backgroundLocations,
+def processBackground(backgroundTags, state: ConversionState, cewe_folder, backgroundLocations,
                       productstyle, pagetype, pdf, ph, pw, context: RenderContext):  # noqa: C901
     """Draw the page background, including special handling for inside covers."""
     areaHeight = ph
@@ -80,7 +81,7 @@ def processBackground(backgroundTags, bg_notFoundDirList, cewe_folder, backgroun
                               width=context.mcf_to_reportlab * areaWidth,
                               height=context.mcf_to_reportlab * areaHeight)
             except Exception:
-                if bgPath not in bg_notFoundDirList:
+                if bgPath not in state.background_not_found_paths:
                     logging.error('Could not find background or error when adding to pdf')
                     logging.exception('Exception')
-                bg_notFoundDirList.add(bgPath)
+                state.background_not_found_paths.add(bgPath)

--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -150,7 +150,7 @@ mcf2rl = reportlab.lib.pagesizes.mm/10 # == 72/254, converts from mcf (unit=0.1m
 # area's centre; rotation therefore behaves like it does in the Album Editor.
 def processElements(additional_fonts, fotobook, imagedir,
                     productstyle, mcfBaseFolder, oddpage, page, pageNumber, pagetype, pdf, pageH, pageW,
-                    lastpage, context: RenderContext, state: ConversionState, albumIndex):
+                    lastpage, context: RenderContext, state: ConversionState):
     if AlbumInfo.isAlbumDoubleSide(productstyle) and pagetype == PageProcessingType.RegularPage and not oddpage and not lastpage:
         # if we are in double-page mode, all the images are drawn by the odd pages.
         return
@@ -199,7 +199,7 @@ def processElements(additional_fonts, fotobook, imagedir,
         # process text
         for textTag in area.findall('text'):
             processAreaTextTag(textTag, additional_fonts, area, areaWidth, areaHeight, areaRot, pdf, transCx, transCy,
-                               pageNumber, context, state, albumIndex)
+                               pageNumber, context, state)
 
         # Clip-Art
         # In the clipartarea there are two similar elements, the <designElementIDs> and the <clipart>.
@@ -230,12 +230,12 @@ def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=No
     setup = prepareConversion(albumname, mcfxTmpDir, appDataDir, conversionState)
 
     if setup.configuration is None:
-        albumIndex = Index(None)
+        conversionState.album_index = Index(None)
     else:
         try:
-            albumIndex = Index(setup.configuration['INDEX'])
+            conversionState.album_index = Index(setup.configuration['INDEX'])
         except KeyError:
-            albumIndex = Index(None)
+            conversionState.album_index = Index(None)
 
     # extract basic album properties
     articleConfigElement = setup.fotobook.find('articleConfig')
@@ -281,11 +281,9 @@ def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=No
             pageNumberingInfo = PageNumberingInfo(pageNumberElement, pdf, setup.available_fonts, conversionState)
     # processPages calls its element-rendering callback with the normal page
     # arguments plus renderContext.  partial() creates an equivalent callback
-    # which also supplies this conversion's mutable state and its album index.
-    # The index remains explicit for now: it is specialised output state,
-    # whereas ConversionState owns general rendering caches and temporary files.
-    processElementsForAlbum = partial(processElements, state=conversionState,
-                                      albumIndex=albumIndex)
+    # which also supplies this conversion's mutable state, including any index
+    # entries found while text areas are rendered.
+    processElementsForAlbum = partial(processElements, state=conversionState)
 
     # `pages` owns CEWE's page/cover selection. It calls our callback for the
     # actual areas once the canvas has been sized and the background drawn.
@@ -301,6 +299,7 @@ def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=No
 
     pdf = []
 
+    albumIndex = conversionState.album_index
     if albumIndex.indexing:
         # At this point we have an index of items (selected on the basis of their font characteristics)
         #   albumIndex.ShowIndex()

--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -90,7 +90,7 @@ from borders import processDecorationBorders
 from clipartareas import processAreaClipartTag
 from conversionSetup import prepareConversion
 from conversionState import ConversionState
-from extraLoggers import VerifyMessageCounts, printMessageCountSummaries
+from extraLoggers import ConversionMessageCounters
 from imageareas import processAreaImageTag
 from pageNumbering import PageNumberingInfo
 from pageTypes import PageProcessingType
@@ -199,7 +199,7 @@ def processElements(additional_fonts, fotobook, imagedir,
         # process text
         for textTag in area.findall('text'):
             processAreaTextTag(textTag, additional_fonts, area, areaWidth, areaHeight, areaRot, pdf, transCx, transCy,
-                               pageNumber, context, albumIndex)
+                               pageNumber, context, state, albumIndex)
 
         # Clip-Art
         # In the clipartarea there are two similar elements, the <designElementIDs> and the <clipart>.
@@ -215,6 +215,8 @@ def processElements(additional_fonts, fotobook, imagedir,
     return
 
 def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=None, appDataDir=None, outputFileName=None): # noqa: C901 (too complex)
+    conversionState = ConversionState()
+    conversionState.message_counters = ConversionMessageCounters()
     logVersionInformation()
     pageNumberingInfo = None
 
@@ -225,8 +227,7 @@ def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=No
         outputFileName = CeweInfo.getOutputFileName(albumname)
     CeweInfo.ensureAcceptableOutputFile(outputFileName)
 
-    setup = prepareConversion(albumname, mcfxTmpDir, appDataDir)
-    conversionState = ConversionState()
+    setup = prepareConversion(albumname, mcfxTmpDir, appDataDir, conversionState)
 
     if setup.configuration is None:
         albumIndex = Index(None)
@@ -252,7 +253,7 @@ def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=No
     imageFolder = setup.fotobook.get('imagedir')
     renderContext = RenderContext(mcf2rl, setup.image_resolution, image_quality, setup.background_resolution,
                                   pil_antialias, setup.default_config_section, setup.clipart_files,
-                                  setup.clipart_paths, setup.passepartout_folders)
+                                  setup.clipart_paths, setup.passepartout_folders, setup.line_scales)
 
     # find the correct size for the album format (if we know!) and set the product style
     pagesize = reportlab.lib.pagesizes.A4
@@ -277,7 +278,7 @@ def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=No
         pnpos = int(pageNumberElement.get('position'))
         if pnpos != 0: # 0 implies no numbering
             # make a page number description object to use later
-            pageNumberingInfo = PageNumberingInfo(pageNumberElement, pdf, setup.available_fonts)
+            pageNumberingInfo = PageNumberingInfo(pageNumberElement, pdf, setup.available_fonts, conversionState)
     # processPages calls its element-rendering callback with the normal page
     # arguments plus renderContext.  partial() creates an equivalent callback
     # which also supplies this conversion's mutable state and its album index.
@@ -318,16 +319,17 @@ def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=No
     objectscollected = gc.collect()
     logging.info(f'GC collected objects : {objectscollected}')
 
-    printMessageCountSummaries()
+    conversionState.message_counters.print_summary()
 
     if productstyle == ProductStyle.MemoryCard:
         print()
         print("Use Adobe Acrobat to print the memory cards. Set custom pages per sheet, 4 wide x 6 down")
         print(" and print two copies!")
 
-    VerifyMessageCounts(setup.default_config_section)
+    conversionState.message_counters.verify(setup.default_config_section)
 
     cleanUpTempFiles(conversionState.temporary_files, setup.unpacked_folder)
+    conversionState.message_counters.close()
 
     return True
 

--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -89,6 +89,7 @@ from ceweInfo import CeweInfo, AlbumInfo, ProductStyle
 from borders import processDecorationBorders
 from clipartareas import processAreaClipartTag
 from conversionSetup import prepareConversion
+from conversionState import ConversionState
 from extraLoggers import VerifyMessageCounts, printMessageCountSummaries
 from imageareas import processAreaImageTag
 from pageNumbering import PageNumberingInfo
@@ -143,15 +144,13 @@ image_quality = 86  # 0=worst, 100=best. This is the JPEG quality option.
 # RenderContext rather than each maintaining its own approximation.
 mcf2rl = reportlab.lib.pagesizes.mm/10 # == 72/254, converts from mcf (unit=0.1mm) to reportlab (unit=inch/72)
 
-tempFileList = []  # we need to remove all the temporary files at the end
-
 # `pages.processPages` identifies the correct MCF page element, including the
 # slightly unusual cover and paired-page rules. This callback dispatches each
 # area to its specialist renderer after translating the PDF origin to the
 # area's centre; rotation therefore behaves like it does in the Album Editor.
 def processElements(additional_fonts, fotobook, imagedir,
                     productstyle, mcfBaseFolder, oddpage, page, pageNumber, pagetype, pdf, pageH, pageW,
-                    lastpage, context: RenderContext, albumIndex):
+                    lastpage, context: RenderContext, state: ConversionState, albumIndex):
     if AlbumInfo.isAlbumDoubleSide(productstyle) and pagetype == PageProcessingType.RegularPage and not oddpage and not lastpage:
         # if we are in double-page mode, all the images are drawn by the odd pages.
         return
@@ -194,6 +193,7 @@ def processElements(additional_fonts, fotobook, imagedir,
         for imageTag in area.findall('imagebackground') + area.findall('image'):
             processAreaImageTag(imageTag, area, areaHeight, areaRot, areaWidth, imagedir, productstyle,
                                 mcfBaseFolder, pagetype, pdf, pageW, transCx, transCy, context,
+                                state,
                                 processDecorationShadow, processDecorationBorders)
 
         # process text
@@ -226,7 +226,7 @@ def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=No
     CeweInfo.ensureAcceptableOutputFile(outputFileName)
 
     setup = prepareConversion(albumname, mcfxTmpDir, appDataDir)
-    bg_notFoundDirList = set([]) # keep a list of background folders that are not found, to prevent multiple errors for the same cause.
+    conversionState = ConversionState()
 
     if setup.configuration is None:
         albumIndex = Index(None)
@@ -252,7 +252,7 @@ def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=No
     imageFolder = setup.fotobook.get('imagedir')
     renderContext = RenderContext(mcf2rl, setup.image_resolution, image_quality, setup.background_resolution,
                                   pil_antialias, setup.default_config_section, setup.clipart_files,
-                                  setup.clipart_paths, None, setup.passepartout_folders, tempFileList)
+                                  setup.clipart_paths, setup.passepartout_folders)
 
     # find the correct size for the album format (if we know!) and set the product style
     pagesize = reportlab.lib.pagesizes.A4
@@ -280,15 +280,16 @@ def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=No
             pageNumberingInfo = PageNumberingInfo(pageNumberElement, pdf, setup.available_fonts)
     # processPages calls its element-rendering callback with the normal page
     # arguments plus renderContext.  partial() creates an equivalent callback
-    # which also supplies this album's index each time it is called.  The index
-    # is mutable output state, so keep it explicit rather than adding it to
-    # RenderContext with the shared rendering resources.
-    processElementsForAlbum = partial(processElements, albumIndex=albumIndex)
+    # which also supplies this conversion's mutable state and its album index.
+    # The index remains explicit for now: it is specialised output state,
+    # whereas ConversionState owns general rendering caches and temporary files.
+    processElementsForAlbum = partial(processElements, state=conversionState,
+                                      albumIndex=albumIndex)
 
     # `pages` owns CEWE's page/cover selection. It calls our callback for the
     # actual areas once the canvas has been sized and the background drawn.
     processPages(setup.fotobook, setup.mcf_base_folder, imageFolder, productstyle, pdf, pageCount, pageNumbers,
-        setup.cewe_folder, setup.available_fonts, setup.background_locations, bg_notFoundDirList, renderContext,
+        setup.cewe_folder, setup.available_fonts, setup.background_locations, conversionState, renderContext,
         pageNumberingInfo, processElementsForAlbum)
 
     # save final output pdf
@@ -326,7 +327,7 @@ def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=No
 
     VerifyMessageCounts(setup.default_config_section)
 
-    cleanUpTempFiles(tempFileList, setup.unpacked_folder)
+    cleanUpTempFiles(conversionState.temporary_files, setup.unpacked_folder)
 
     return True
 

--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -65,6 +65,10 @@ if __name__ == '__main__' and len(sys.argv) == 2 and sys.argv[1] == '--version':
     print(getVersionInformationText())
     sys.exit(0)
 
+# These imports deliberately follow the lightweight --version exit above.  Do
+# not move them before it: doing so would load image libraries merely to report
+# a program version from a standalone executable.
+# pylint: disable=wrong-import-position,wrong-import-order
 import logging
 import logging.config
 
@@ -97,7 +101,7 @@ from pageTypes import PageProcessingType
 from pages import getPageElementForPageNumber, processPages
 from renderContext import RenderContext
 from textareas import processAreaTextTag
-from index import Index
+from albumIndex import AlbumIndex
 from shadows import processDecorationShadow
 
 
@@ -150,7 +154,7 @@ mcf2rl = reportlab.lib.pagesizes.mm/10 # == 72/254, converts from mcf (unit=0.1m
 # area's centre; rotation therefore behaves like it does in the Album Editor.
 def processElements(additional_fonts, fotobook, imagedir,
                     productstyle, mcfBaseFolder, oddpage, page, pageNumber, pagetype, pdf, pageH, pageW,
-                    lastpage, context: RenderContext, state: ConversionState):
+                    lastpage, context: RenderContext, state: ConversionState, albumIndex: AlbumIndex):
     if AlbumInfo.isAlbumDoubleSide(productstyle) and pagetype == PageProcessingType.RegularPage and not oddpage and not lastpage:
         # if we are in double-page mode, all the images are drawn by the odd pages.
         return
@@ -199,7 +203,7 @@ def processElements(additional_fonts, fotobook, imagedir,
         # process text
         for textTag in area.findall('text'):
             processAreaTextTag(textTag, additional_fonts, area, areaWidth, areaHeight, areaRot, pdf, transCx, transCy,
-                               pageNumber, context, state)
+                               pageNumber, context, state, albumIndex)
 
         # Clip-Art
         # In the clipartarea there are two similar elements, the <designElementIDs> and the <clipart>.
@@ -230,12 +234,12 @@ def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=No
     setup = prepareConversion(albumname, mcfxTmpDir, appDataDir, conversionState)
 
     if setup.configuration is None:
-        conversionState.album_index = Index(None)
+        albumIndex = AlbumIndex(None)
     else:
         try:
-            conversionState.album_index = Index(setup.configuration['INDEX'])
+            albumIndex = AlbumIndex(setup.configuration['INDEX'])
         except KeyError:
-            conversionState.album_index = Index(None)
+            albumIndex = AlbumIndex(None)
 
     # extract basic album properties
     articleConfigElement = setup.fotobook.find('articleConfig')
@@ -281,9 +285,9 @@ def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=No
             pageNumberingInfo = PageNumberingInfo(pageNumberElement, pdf, setup.available_fonts, conversionState)
     # processPages calls its element-rendering callback with the normal page
     # arguments plus renderContext.  partial() creates an equivalent callback
-    # which also supplies this conversion's mutable state, including any index
-    # entries found while text areas are rendered.
-    processElementsForAlbum = partial(processElements, state=conversionState)
+    # The index is an optional text-processing feature.  Passing it explicitly
+    # keeps it outside the general rendering state used by every area type.
+    processElementsForAlbum = partial(processElements, state=conversionState, albumIndex=albumIndex)
 
     # `pages` owns CEWE's page/cover selection. It calls our callback for the
     # actual areas once the canvas has been sized and the background drawn.
@@ -299,7 +303,6 @@ def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=No
 
     pdf = []
 
-    albumIndex = conversionState.album_index
     if albumIndex.indexing:
         # At this point we have an index of items (selected on the basis of their font characteristics)
         #   albumIndex.ShowIndex()

--- a/cewe2pdf.pyproj
+++ b/cewe2pdf.pyproj
@@ -326,6 +326,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="conversionSetup.py" />
+    <Compile Include="conversionState.py" />
     <Compile Include="corners.py" />
     <Compile Include="fontHandling.py">
       <SubType>Code</SubType>

--- a/conversionSetup.py
+++ b/conversionSetup.py
@@ -21,6 +21,7 @@ from lxml import etree
 from ceweInfo import CeweInfo
 from clipArt import readClipArtConfigXML
 from configUtils import getConfigurationInt
+from conversionState import ConversionState
 from extraLoggers import mustsee
 from fontHandling import findAndRegisterFonts
 from lineScales import LineScales
@@ -30,28 +31,40 @@ from pathutils import findFileInDirs
 
 @dataclass
 class ConversionSetup:
-    """Input and resources resolved before the PDF canvas is created."""
+    """Input and read-only resources resolved before the PDF canvas is created.
 
-    album_title: str
-    mcf_xml_name: str
-    unpacked_folder: str | None
-    album_base_folder: str
-    mcf_base_folder: str
-    fotobook: Any
-    configuration: configparser.ConfigParser | None
-    default_config_section: Any
-    cewe_folder: str
-    key_account_folder: str | None
-    background_locations: tuple[str, ...]
-    passepartout_folders: tuple[str, ...]
-    clipart_files: dict[int, str]
-    clipart_paths: tuple[str, ...]
-    image_resolution: int
-    background_resolution: int
-    available_fonts: Any
+    Values here describe the album and its configured rendering environment.
+    Data discovered while rendering belongs in :class:`ConversionState`
+    instead, so it is clear which values are safe to share with all pages.
+    """
+
+    cewe_folder: str                # CEWE installation/data root, from cewe_folder.txt or cewe2pdf.ini.
+    key_account_folder: str | None  # Account-specific CEWE data directory when one can be determined.
+
+    configuration: configparser.ConfigParser | None    # Merged INI configuration, or None when the legacy cewe_folder.txt path was used.
+    default_config_section: Any             # The DEFAULT INI section, passed to renderers needing an individual setting.
+
+    background_locations: tuple[str, ...]   # Ordered directories searched for CEWE page-background images.
+    clipart_files: dict[int, str]           # Extra clipart ID-to-file mappings configured in the INI file.
+    clipart_paths: tuple[str, ...]          # Clipart XML/resource search paths resolved from the CEWE installation.
+    passepartout_folders: tuple[str, ...]   # Ordered directories searched when building the passepartout index.
+
+    mcf_xml_name: str           # Actual XML file to parse: the source MCF, or data.mcf unpacked from MCFX.
+    mcf_base_folder: str        # Folder containing mcf_xml_name, used to resolve album image references.
+    unpacked_folder: str | None # TemporaryDirectory returned when an MCFX archive was unpacked; otherwise None.
+    album_base_folder: str      # Original album location, used to find its optional configuration file.
+
+    fotobook: Any       # Root <fotobook> XML element used by the page-processing stage.
+    album_title: str    # Human-readable album name, used as the PDF document title.
+
+    available_fonts: Any        # Font faces successfully registered with ReportLab for this conversion.
+    line_scales: LineScales     # Default and per-font line-spacing rules read from the INI configuration.
+
+    image_resolution: int       # Target DPI for ordinary images.
+    background_resolution: int  # Target DPI for page-background images.
 
 
-def prepareConversion(albumname, mcfxTmpDir, appDataDir) -> ConversionSetup: # noqa: C901
+def prepareConversion(albumname, mcfxTmpDir, appDataDir, state: ConversionState) -> ConversionSetup: # noqa: C901
     """Read an album and resolve the configuration and resources it requires."""
     albumTitle, dummy = os.path.splitext(os.path.basename(albumname))
 
@@ -147,16 +160,32 @@ def prepareConversion(albumname, mcfxTmpDir, appDataDir) -> ConversionSetup: # n
 
     mustsee.info(f'Using image resolution {imageResolution}, background resolution {backgroundResolution}')
 
-    LineScales.setupDefaultLineScale(defaultConfigSection)
+    lineScales = LineScales(defaultConfigSection)
     if keyAccountFolder is not None:
         passepartoutFolders += CeweInfo.getCewePassepartoutFolders(ceweFolder, keyAccountFolder)
 
-    availableFonts = findAndRegisterFonts(defaultConfigSection, appDataDir, albumBaseFolder, ceweFolder)
-    LineScales.setupFontLineScales(defaultConfigSection)
+    availableFonts = findAndRegisterFonts(defaultConfigSection, appDataDir, albumBaseFolder, ceweFolder, state)
     clipartPaths = readClipArtConfigXML(ceweFolder, keyAccountFolder, clipartFiles)
 
+    # Use names here rather than relying on ConversionSetup's declaration
+    # order.  The dataclass is intentionally grouped for readability above,
+    # and its fields should be freely rearrangeable without changing values.
     return ConversionSetup(
-        albumTitle, mcfxmlname, unpackedFolder, albumBaseFolder, mcfBaseFolder,
-        fotobook, configuration, defaultConfigSection, ceweFolder, keyAccountFolder,
-        backgroundLocations, passepartoutFolders, clipartFiles, clipartPaths,
-        imageResolution, backgroundResolution, availableFonts)
+        cewe_folder=ceweFolder,
+        key_account_folder=keyAccountFolder,
+        configuration=configuration,
+        default_config_section=defaultConfigSection,
+        background_locations=backgroundLocations,
+        clipart_files=clipartFiles,
+        clipart_paths=clipartPaths,
+        passepartout_folders=passepartoutFolders,
+        mcf_xml_name=mcfxmlname,
+        mcf_base_folder=mcfBaseFolder,
+        unpacked_folder=unpackedFolder,
+        album_base_folder=albumBaseFolder,
+        fotobook=fotobook,
+        album_title=albumTitle,
+        available_fonts=availableFonts,
+        line_scales=lineScales,
+        image_resolution=imageResolution,
+        background_resolution=backgroundResolution)

--- a/conversionState.py
+++ b/conversionState.py
@@ -24,7 +24,4 @@ class ConversionState:
     passepartout_files: dict[int, str] | None = None
     missing_font_substitutions: dict[str, str] = field(default_factory=dict)
     noted_font_substitutions: set[str] = field(default_factory=set)
-    # Index is configured before rendering, but its entries are discovered by
-    # text areas and it is rendered only after the album PDF has been saved.
-    album_index: Any | None = None
     message_counters: Any | None = None

--- a/conversionState.py
+++ b/conversionState.py
@@ -7,12 +7,21 @@ Python process.
 """
 
 from dataclasses import dataclass, field
+from typing import Any
 
 
 @dataclass
 class ConversionState:
-    """Mutable per-conversion caches and temporary output files."""
+    """Mutable per-conversion caches, diagnostics, and temporary files.
+
+    Font substitutions and message counters are deliberately here rather than
+    at module scope: an album's configuration and its diagnostics must not
+    affect the next album when a caller invokes :func:`convertMcf` twice.
+    """
 
     temporary_files: list[str] = field(default_factory=list)
     background_not_found_paths: set[str] = field(default_factory=set)
     passepartout_files: dict[int, str] | None = None
+    missing_font_substitutions: dict[str, str] = field(default_factory=dict)
+    noted_font_substitutions: set[str] = field(default_factory=set)
+    message_counters: Any | None = None

--- a/conversionState.py
+++ b/conversionState.py
@@ -1,0 +1,18 @@
+"""Mutable state belonging to one CEWE-to-PDF conversion.
+
+Rendering resources and settings live in :mod:`renderContext`.  This separate
+object owns information which is discovered or created while a conversion is
+under way, so it cannot accidentally leak into a later conversion in the same
+Python process.
+"""
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ConversionState:
+    """Mutable per-conversion caches and temporary output files."""
+
+    temporary_files: list[str] = field(default_factory=list)
+    background_not_found_paths: set[str] = field(default_factory=set)
+    passepartout_files: dict[int, str] | None = None

--- a/conversionState.py
+++ b/conversionState.py
@@ -24,4 +24,7 @@ class ConversionState:
     passepartout_files: dict[int, str] | None = None
     missing_font_substitutions: dict[str, str] = field(default_factory=dict)
     noted_font_substitutions: set[str] = field(default_factory=set)
+    # Index is configured before rendering, but its entries are discovered by
+    # text areas and it is rendered only after the album PDF has been saved.
+    album_index: Any | None = None
     message_counters: Any | None = None

--- a/extraLoggers.py
+++ b/extraLoggers.py
@@ -19,19 +19,33 @@ mustsee = logging.getLogger("cewe2pdf.mustsee")
 # a logger for configuration, to distinguish that from logging in the album processing
 configlogger = logging.getLogger("cewe2pdf.config")
 
-# create log output handlers which count messages at each level
-rootMessageCountHandler = MsgCounterHandler()
-rootMessageCountHandler.setLevel(logging.DEBUG) # ensuring that it counts everything
-logging.getLogger().addHandler(rootMessageCountHandler)
+class ConversionMessageCounters:
+    """Count log records for one conversion and detach cleanly afterwards.
 
-configMessageCountHandler = MsgCounterHandler()
-configMessageCountHandler.setLevel(logging.DEBUG) # ensuring that it counts everything
-configlogger.addHandler(configMessageCountHandler)
+    The handlers deliberately count records before logger-level filtering, as
+    did the original global handlers.  Their lifetime is now one conversion,
+    rather than the whole Python process, so consecutive conversions no longer
+    inherit one another's expected-message totals.
+    """
 
+    def __init__(self):
+        self.root_handler = MsgCounterHandler()
+        self.root_handler.setLevel(logging.DEBUG)
+        logging.getLogger().addHandler(self.root_handler)
 
-def VerifyMessageCounts(configSection):
-    # if he has specified "normal" values for the number of messages of each kind, then warn if we do not see that number
-    if configSection is not None:
+        self.config_handler = MsgCounterHandler()
+        self.config_handler.setLevel(logging.DEBUG)
+        configlogger.addHandler(self.config_handler)
+
+    def close(self):
+        """Detach the handlers once the conversion has reported its totals."""
+        logging.getLogger().removeHandler(self.root_handler)
+        configlogger.removeHandler(self.config_handler)
+
+    def verify(self, configSection):
+        # if he has specified "normal" values for the number of messages of each kind, then warn if we do not see that number
+        if configSection is None:
+            return
         # the expectedLoggingMessageCounts section is one or more newline separated list of
         #   loggername: levelname[count], ...
         # e.g.
@@ -45,16 +59,15 @@ def VerifyMessageCounts(configSection):
                 loggerName = items[0].strip()
                 leveldefs = items[1].strip() # a comma separated list of levelname[count]
                 if loggerName == configlogger.name:
-                    configMessageCountHandler.checkCounts(loggerName,leveldefs)
+                    self.config_handler.checkCounts(loggerName,leveldefs)
                 elif loggerName == logging.getLogger().name:
-                    rootMessageCountHandler.checkCounts(loggerName,leveldefs)
+                    self.root_handler.checkCounts(loggerName,leveldefs)
                 else:
                     print(f"Invalid expectedLoggingMessageCounts logger name, entry ignored: {loggerdef}")
             else:
                 print(f"Invalid expectedLoggingMessageCounts entry ignored: {loggerdef}")
 
-
-def printMessageCountSummaries():
-    print("Total message counts, including messages suppressed by logger configuration")
-    print(f" cewe2pdf.config: {configMessageCountHandler.messageCountText()}")
-    print(f" root:            {rootMessageCountHandler.messageCountText()}")
+    def print_summary(self):
+        print("Total message counts, including messages suppressed by logger configuration")
+        print(f" cewe2pdf.config: {self.config_handler.messageCountText()}")
+        print(f" root:            {self.root_handler.messageCountText()}")

--- a/fontHandling.py
+++ b/fontHandling.py
@@ -6,14 +6,13 @@ from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont
 
 from ceweInfo import CeweInfo
+from conversionState import ConversionState
 from extraLoggers import mustsee, configlogger
 from otf import getTtfsFromOtfs
 from pathutils import localfont_dir, findFileInDirs, findFilesInDir
 
-fontSubstitutions = list[str]() # used to avoid repeated messages
-
-
-def findAndRegisterFonts(configSection, appDataDir, albumBaseFolder, cewe_folder): # pylint: disable=too-many-statements
+def findAndRegisterFonts(configSection, appDataDir, albumBaseFolder, cewe_folder,
+                         state: ConversionState): # pylint: disable=too-many-statements
     ttfFiles = []
     fontDirs = []
     fontsToRegister = {}
@@ -95,7 +94,7 @@ def findAndRegisterFonts(configSection, appDataDir, albumBaseFolder, cewe_folder
     #  but ignoring any family name which was registered explicitly from configuration
     registerFontFamilies(familiesToRegister, explicitlyRegisteredFamilyNames)
 
-    loadMissingFontSubstitutions(configSection, fontsToRegister)
+    loadMissingFontSubstitutions(configSection, fontsToRegister, state)
 
     logging.info("Ended font registration")
 
@@ -293,7 +292,7 @@ def registerFontFamilies(fontFamilies, explicitlyRegisteredFamilyNames):
 
 # if a font is missing when we need it then we'll try to find an
 # alternative from this table
-missingFontSubstitutions = {
+DEFAULT_MISSING_FONT_SUBSTITUTIONS = {
     "Arial": "Liberation Sans Narrow",
     "Arial Narrow": "Liberation Sans Narrow",
     "Arial Rounded MT Bold": "Poppins",
@@ -311,8 +310,14 @@ missingFontSubstitutions = {
     # Segoe UI Symbol
     }
 
-def loadMissingFontSubstitutions(configSection, availableFonts):
-    global missingFontSubstitutions  # pylint: disable=global-statement
+def loadMissingFontSubstitutions(configSection, availableFonts, state: ConversionState):
+    """Build this conversion's missing-font substitution table.
+
+    The defaults remain constants in this module, but the editable mapping and
+    the record of warnings both belong to ConversionState.  That avoids a
+    previous album's INI settings leaking into a later album conversion.
+    """
+    state.missing_font_substitutions = dict(DEFAULT_MISSING_FONT_SUBSTITUTIONS)
     if configSection is None:
         return
     # build the known missing font substitutions table
@@ -325,32 +330,32 @@ def loadMissingFontSubstitutions(configSection, availableFonts):
             originalfont = definition[0].strip()
             newfont = definition[1].strip()
             if originalfont == '' and newfont == '':
-                missingFontSubstitutions = {}
+                state.missing_font_substitutions = {}
             else:
                 if originalfont != '' and newfont != '':
                     if newfont not in availableFonts:
                         configlogger.error(f"Font substitution with '{newfont}' ignored, that font has not been found")
                         continue
-                    missingFontSubstitutions[originalfont] = newfont
+                    state.missing_font_substitutions[originalfont] = newfont
                 else:
                     configlogger.error(f"Invalid font substitution '{originalfont}' : '{newfont}' ignored")
                     continue
 
 
-def getMissingFontSubstitute(family):
-    if family in missingFontSubstitutions: # IMO this is clearest so pylint: disable=consider-using-get
-        bodyfont = missingFontSubstitutions[family]
+def getMissingFontSubstitute(family, state: ConversionState):
+    if family in state.missing_font_substitutions: # IMO this is clearest so pylint: disable=consider-using-get
+        bodyfont = state.missing_font_substitutions[family]
     else:
         bodyfont = 'Helvetica'
         # reportlabs actually offers Helvetica, which is a bit strange since it is a proprietary font.
     return bodyfont
 
 
-def noteFontSubstitution(family, replacement):
+def noteFontSubstitution(family, replacement, state: ConversionState):
     fontSubstitutionPair = family + "/" + replacement
-    fontSubsNotedAlready = fontSubstitutionPair in fontSubstitutions
+    fontSubsNotedAlready = fontSubstitutionPair in state.noted_font_substitutions
     if not fontSubsNotedAlready:
-        fontSubstitutions.append(fontSubstitutionPair)
+        state.noted_font_substitutions.add(fontSubstitutionPair)
     if logging.root.isEnabledFor(logging.DEBUG):
         # At DEBUG level we log all font substitutions, making it easier to find them in the mcf
         logging.debug(f"Using font family = '{replacement}' (wanted {family})")
@@ -360,13 +365,13 @@ def noteFontSubstitution(family, replacement):
         logging.warning(f"Using font family = '{replacement}' (wanted {family})")
 
 
-def getAvailableFont(family, pdf, additional_fonts):
+def getAvailableFont(family, pdf, additional_fonts, state: ConversionState):
     reportlabFonts = pdf.getAvailableFonts()
     if family in reportlabFonts:
         bodyfont = family
     elif family in additional_fonts:
         bodyfont = family
     else:
-        bodyfont = getMissingFontSubstitute(family)
-        noteFontSubstitution(family, bodyfont)
+        bodyfont = getMissingFontSubstitute(family, state)
+        noteFontSubstitution(family, bodyfont, state)
     return bodyfont

--- a/imageareas.py
+++ b/imageareas.py
@@ -11,6 +11,7 @@ from reportlab.lib.utils import ImageReader
 from ceweInfo import AlbumInfo
 from clipArt import getClipConfig, loadClipart
 from clipartareas import insertClipartFile
+from conversionState import ConversionState
 from corners import applyCornerMask, getCornersInfo
 from imageUtils import autorot
 from passepartout import Passepartout
@@ -19,7 +20,8 @@ from renderContext import RenderContext
 
 def processAreaImageTag(imageTag, area, areaHeight, areaRot, areaWidth, imageDirectory,
                         productStyle, mcfBaseFolder, pageType, pdf, pageWidth,
-                        transx, transy, context: RenderContext, drawShadow, drawBorders):
+                        transx, transy, context: RenderContext, state: ConversionState,
+                        drawShadow, drawBorders):
     """Crop, decorate and draw one CEWE image area."""
     if imageTag.get('filename') is None:
         return
@@ -57,11 +59,11 @@ def processAreaImageTag(imageTag, area, areaHeight, areaRot, areaWidth, imageDir
     imageCropHeight_mcfunit = areaHeight
     if passepartoutId is not None:
         passepartoutId = int(passepartoutId)
-        if context.passepartout_files is None:
+        if state.passepartout_files is None:
             logging.info("Regenerating passepartout index from .XML files.")
-            context.passepartout_files = Passepartout.buildElementIdIndex(context.passepartout_folders)
+            state.passepartout_files = Passepartout.buildElementIdIndex(context.passepartout_folders)
         try:
-            passepartoutXmlFileName = context.passepartout_files[passepartoutId]
+            passepartoutXmlFileName = state.passepartout_files[passepartoutId]
         except KeyError:
             passepartoutXmlFileName = None
         if passepartoutXmlFileName is None:
@@ -126,7 +128,7 @@ def processAreaImageTag(imageTag, area, areaHeight, areaRot, areaWidth, imageDir
     pdf.translate(-frameShiftX_mcf * mcf2rl, -frameShiftY_mcf * mcf2rl)
 
     for decorationTag in area.findall('decoration'):
-        drawShadow(decorationTag, areaHeight, areaWidth, pdf, context,
+        drawShadow(decorationTag, areaHeight, areaWidth, pdf, context, state,
                    image, imageCropWidth_mcfunit, imageCropHeight_mcfunit)
 
     pdf.drawImage(ImageReader(temporaryImage.name),
@@ -148,5 +150,4 @@ def processAreaImageTag(imageTag, area, areaHeight, areaRot, areaWidth, imageDir
     pdf.rotate(areaRot)
     pdf.translate(-imageTransx, -transy)
 
-    if context.temporary_files is not None:
-        context.temporary_files.append(temporaryImage.name)
+    state.temporary_files.append(temporaryImage.name)

--- a/lineScales.py
+++ b/lineScales.py
@@ -1,25 +1,32 @@
 from extraLoggers import mustsee, configlogger
 
-class LineScales():
+class LineScales:
+    """Line-spacing settings read for one conversion.
 
-    defaultLineScale = 1.1 # line scale if not overridden. Best to configure to 1.15 - don't break old albums by changing here
-    fontLineScales = {} # mapping fontnames to linescale where the standard defaultLineScale is not ok
+    These used to be class attributes, which meant a conversion could change
+    the spacing used by a later conversion in the same Python process.
+    Keeping them together in this small object makes the configuration
+    lifetime explicit and leaves the renderer free of mutable module state.
+    """
 
-    def __init__(self):
-        return
+    def __init__(self, configSection):
+        # Best to configure 1.15 in new setups; retain 1.1 as the historical
+        # fallback so old albums are not silently reformatted.
+        self.default_line_scale = 1.1
+        self.font_line_scales = {}
+        self._setupDefaultLineScale(configSection)
+        self._setupFontLineScales(configSection)
 
-    @staticmethod
-    def setupDefaultLineScale(configSection):
+    def _setupDefaultLineScale(self, configSection):
         if configSection is not None:
             try:
                 dls = configSection.getfloat('defaultLineScale', 1.15)
-                LineScales.defaultLineScale = dls
+                self.default_line_scale = dls
             except:# noqa: E722  # pylint: disable=bare-except
                 configlogger.error("Invalid defaultLineScale in .ini file")
-        mustsee.info(f"Default line scale = {LineScales.defaultLineScale}")
+        mustsee.info(f"Default line scale = {self.default_line_scale}")
 
-    @staticmethod
-    def setupFontLineScales(configSection):
+    def _setupFontLineScales(self, configSection):
         if configSection is not None:
             ff = configSection.get('fontLineScales', '').splitlines()  # newline separated list of fontname : line_scale
             specifiedLineScales = filter(lambda bg: (len(bg) != 0), ff)
@@ -29,15 +36,14 @@ class LineScales():
                     fontName = scaleItems[0].strip()
                     try:
                         scale = float(scaleItems[1].strip())
-                        LineScales.fontLineScales[fontName] = scale
-                        configlogger.info(f"Font {fontName} uses non-standard line scale {LineScales.fontLineScales[fontName]}")
+                        self.font_line_scales[fontName] = scale
+                        configlogger.info(f"Font {fontName} uses non-standard line scale {self.font_line_scales[fontName]}")
                     except ValueError:
                         configlogger.error(f"Invalid line scale value {scaleItems[1]} ignored for {fontName}")
                 else:
                     configlogger.error(f"Invalid lineScales entry ignored (should be 'FontName: Scale'): {specifiedLineScale}")
 
-    @staticmethod
-    def lineScaleForFont(font):
-        if font in LineScales.fontLineScales:
-            return LineScales.fontLineScales[font]
-        return LineScales.defaultLineScale
+    def lineScaleForFont(self, font):
+        if font in self.font_line_scales:
+            return self.font_line_scales[font]
+        return self.default_line_scale

--- a/pageNumbering.py
+++ b/pageNumbering.py
@@ -7,6 +7,7 @@ from reportlab.lib.styles import ParagraphStyle
 from ceweInfo import ProductStyle
 from colorFrame import ColorFrame
 from colorUtils import ReorderColorBytesMcf2Rl
+from conversionState import ConversionState
 from fontHandling import getAvailableFont
 from renderContext import RenderContext
 from textoutlines import TextEffectsParagraph
@@ -52,7 +53,7 @@ class PageNumberFormat(Enum):
 
 
 class PageNumberingInfo:
-    def __init__(self, pageNumberElement, pdf, availableFonts):
+    def __init__(self, pageNumberElement, pdf, availableFonts, state: ConversionState):
         """
         Constructor that initializes the page numbering info from the given lxml element.
         """
@@ -65,7 +66,7 @@ class PageNumberingInfo:
         self.horizontalMargin = int(pageNumberElement.get('margin','50')) * mcf2rl # * 0.1 mm
         self.verticalMargin = int(pageNumberElement.get('verticalMargin','50')) * mcf2rl # * 0.1 mm
         fontfamily = pageNumberElement.get('fontfamily','Liberation Sans')
-        self.fontfamily = getAvailableFont(fontfamily, pdf, availableFonts)
+        self.fontfamily = getAvailableFont(fontfamily, pdf, availableFonts, state)
         self.fontsize = int(pageNumberElement.get('fontsize','12'))
         self.fontbold = int(pageNumberElement.get('fontbold','0'))
         self.fontitalics = int(pageNumberElement.get('fontitalics','0'))

--- a/pages.py
+++ b/pages.py
@@ -8,6 +8,7 @@ from typing import Callable
 # pylint: disable=broad-exception-caught
 
 from backgrounds import processBackground
+from conversionState import ConversionState
 from ceweInfo import AlbumInfo
 from pageNumbering import addPageNumber
 from pageTypes import PageProcessingType
@@ -21,7 +22,7 @@ def getPageElementForPageNumber(fotobook, pageNumber):
 
 def parseInputPage(fotobook, ceweFolder, mcfBaseFolder, backgroundLocations, imageDirectory, pdf,
                    page, pageNumber, pageCount, pageType, productStyle, oddPage,
-                   backgroundNotFoundDirectories, availableFonts, lastPage,
+                   state: ConversionState, availableFonts, lastPage,
                    context: RenderContext, processElements: Callable):
     """Set up one output page, draw its background, then delegate its areas."""
     logging.info(f"Side {pageNumber} ({pageType}): parsing pagenr {page.get('pagenr')} of {pageCount}")
@@ -42,7 +43,7 @@ def parseInputPage(fotobook, ceweFolder, mcfBaseFolder, backgroundLocations, ima
     # The designElementIDs preceding the background element match it only for
     # an original, unfiltered stock background.
     backgroundTags = page.findall('background')
-    processBackground(backgroundTags, backgroundNotFoundDirectories, ceweFolder,
+    processBackground(backgroundTags, state, ceweFolder,
                       backgroundLocations, productStyle, pageType, pdf,
                       pageHeight, pageWidth, context)
 
@@ -60,7 +61,7 @@ def parseInputPage(fotobook, ceweFolder, mcfBaseFolder, backgroundLocations, ima
 
 def processPages(fotobook, mcfBaseFolder, imageDirectory, productStyle, pdf, pageCount,  # noqa: C901
                  pageNumbers, ceweFolder, availableFonts, backgroundLocations,
-                 backgroundNotFoundDirectories, context: RenderContext,
+                 state: ConversionState, context: RenderContext,
                  pageNumberingInfo, processElements: Callable):
     """Render the requested album pages, including covers and inside covers."""
 
@@ -120,7 +121,7 @@ def processPages(fotobook, mcfBaseFolder, imageDirectory, productStyle, pdf, pag
                     lastPage = False
                     parseInputPage(fotobook, ceweFolder, mcfBaseFolder, backgroundLocations,
                                    imageDirectory, pdf, realFirstPages[0], pageNumber, pageCount,
-                                   pageType, productStyle, oddPage, backgroundNotFoundDirectories,
+                                   pageType, productStyle, oddPage, state,
                                    availableFonts, lastPage, context, processElements)
                 pageType = PageProcessingType.FrontInsideCover
 
@@ -132,7 +133,7 @@ def processPages(fotobook, mcfBaseFolder, imageDirectory, productStyle, pdf, pag
                     pageType = PageProcessingType.RegularPage
                     parseInputPage(fotobook, ceweFolder, mcfBaseFolder, backgroundLocations,
                                    imageDirectory, pdf, page, pageNumber, pageCount, pageType,
-                                   productStyle, oddPage, backgroundNotFoundDirectories,
+                                   productStyle, oddPage, state,
                                    availableFonts, lastPage, context, processElements)
                     addPageNumber(pageNumberingInfo, pdf, pageNumber,
                                   productStyle, oddPage, context)
@@ -167,7 +168,7 @@ def processPages(fotobook, mcfBaseFolder, imageDirectory, productStyle, pdf, pag
                     continue
                 parseInputPage(fotobook, ceweFolder, mcfBaseFolder, backgroundLocations,
                                imageDirectory, pdf, page, pageNumber, pageCount, pageType,
-                               productStyle, oddPage, backgroundNotFoundDirectories,
+                               productStyle, oddPage, state,
                                availableFonts, lastPage, context, processElements)
 
                 if AlbumInfo.isAlbumProduct(productStyle) and pageType in [

--- a/renderContext.py
+++ b/renderContext.py
@@ -22,3 +22,4 @@ class RenderContext:
     clipart_files: dict[int, str]
     clipart_paths: tuple[str, ...]
     passepartout_folders: tuple[str, ...] = ()
+    line_scales: Any = None

--- a/renderContext.py
+++ b/renderContext.py
@@ -21,6 +21,4 @@ class RenderContext:
     default_config_section: Any
     clipart_files: dict[int, str]
     clipart_paths: tuple[str, ...]
-    passepartout_files: dict[int, str] | None = None
     passepartout_folders: tuple[str, ...] = ()
-    temporary_files: list[str] | None = None

--- a/runAllTests.py
+++ b/runAllTests.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 os.environ['IGNORELOCALFONTS'] = "1"
 

--- a/shadows.py
+++ b/shadows.py
@@ -11,6 +11,7 @@ from reportlab.lib.utils import ImageReader
 from reportlab.platypus import Table
 
 from configUtils import getConfigurationBool
+from conversionState import ConversionState
 from renderContext import RenderContext
 
 def findShadowBottomLeft(frameBottomLeft, angle, distance, swidth):
@@ -37,11 +38,11 @@ def intensityToGrey(value):
 def drawBlurredImageShadow(pdf, im, imgCropWidth_mcfunit,
                            imgCropHeight_mcfunit, shadowDistance_mcfunit,
                            shadowAngle, intensity, shadowBlur_mcfunit,
-                           shadowWidth_mcfunit, mcf2rl, tempFileList):
+                           shadowWidth_mcfunit, mcf2rl, temporary_files):
     """
     Draw a blurred, transparent shadow using the image's existing alpha mask.
 
-    ``tempFileList`` belongs to the caller's PDF-generation lifecycle. The
+    ``temporary_files`` belongs to the caller's PDF-generation lifecycle. The
     generated PNG is therefore retained until the PDF has been completed.
     """
     if im.mode != 'RGBA':
@@ -94,7 +95,7 @@ def drawBlurredImageShadow(pdf, im, imgCropWidth_mcfunit,
     shadowFile = tempfile.NamedTemporaryFile() # pylint:disable=consider-using-with
     shadowFile.close()
     shadowImage.save(shadowFile.name, 'PNG')
-    tempFileList.append(shadowFile.name)
+    temporary_files.append(shadowFile.name)
 
     # CEWE stores the direction in the same convention used by the older
     # vector shadow code: the angle identifies where the shadow is cast, not
@@ -120,7 +121,7 @@ def drawBlurredImageShadow(pdf, im, imgCropWidth_mcfunit,
 
 
 def processDecorationShadow(decoration, areaHeight, areaWidth, pdf,
-                            context: RenderContext, im=None,
+                            context: RenderContext, state: ConversionState, im=None,
                             imgCropWidth_mcfunit=None,
                             imgCropHeight_mcfunit=None):
     """Draw an enabled CEWE shadow decoration for an already-positioned area."""
@@ -173,7 +174,7 @@ def processDecorationShadow(decoration, areaHeight, areaWidth, pdf,
                 pdf, im, imgCropWidth_mcfunit, imgCropHeight_mcfunit,
                 shadowDistance_mcfunit, shadowAngle, intensity,
                 shadowBlur_mcfunit, shadowWidth_mcfunit, mcf2rl,
-                context.temporary_files
+                state.temporary_files
             )
         else:
             shadowBottomLeftX, shadowBottomLeftY = findShadowBottomLeft(

--- a/text.py
+++ b/text.py
@@ -6,16 +6,17 @@ from reportlab.pdfbase import pdfmetrics
 
 from fontHandling import getAvailableFont
 from lineScales import LineScales
+from conversionState import ConversionState
 
 
-def CreateParagraphStyle(textcolor, font, fontsize, font_size_adjust):
+def CreateParagraphStyle(textcolor, font, fontsize, font_size_adjust, line_scales: LineScales):
     # apply a tiny adjustment to the font size used by ReportLab for measuring
     adjusted_fs = fontsize * font_size_adjust
     parastyle = ParagraphStyle(None, None,
         alignment=reportlab.lib.enums.TA_LEFT,  # will often be overridden
         fontSize=adjusted_fs,
         fontName=font,
-        leading=adjusted_fs * LineScales.lineScaleForFont(font),  # line spacing (text + leading)
+        leading=adjusted_fs * line_scales.lineScaleForFont(font),  # line spacing (text + leading)
         borderPadding=0,
         borderWidth=0,
         leftIndent=0,
@@ -26,7 +27,7 @@ def CreateParagraphStyle(textcolor, font, fontsize, font_size_adjust):
     return parastyle
 
 
-def LeadingForExplicitLineHeight(font, fontsize, line_height):
+def LeadingForExplicitLineHeight(font, fontsize, line_height, line_scales: LineScales):
     """
     Return ReportLab leading for a CSS line-height percentage.
 
@@ -36,7 +37,7 @@ def LeadingForExplicitLineHeight(font, fontsize, line_height):
     our configured leading.  Use the same natural line box as the baseline,
     then apply the requested percentage consistently.
     """
-    configured_leading = fontsize * LineScales.lineScaleForFont(font)
+    configured_leading = fontsize * line_scales.lineScaleForFont(font)
     try:
         ascent, descent = pdfmetrics.getAscentDescent(font, fontsize)
         natural_leading = ascent - descent
@@ -78,7 +79,8 @@ def Dequote(s):
     # we can not delete now, because file is opened by pdf library
 
 
-def CollectFontInfo(item, pdf, additional_fonts, dfltfont, dfltfs, bweight, fontScaleFactor):
+def CollectFontInfo(item, pdf, additional_fonts, dfltfont, dfltfs, bweight,
+                    fontScaleFactor, state: ConversionState):
     if item is None:
         return dfltfont, dfltfs, bweight, {}
     spanfont = dfltfont
@@ -88,7 +90,7 @@ def CollectFontInfo(item, pdf, additional_fonts, dfltfont, dfltfs, bweight, font
                     item.get('style').lstrip(' ').rstrip(';').split('; ')])
     if 'font-family' in spanstyle:
         spanfamily = spanstyle['font-family'].strip("'")
-        spanfont = getAvailableFont(spanfamily, pdf, additional_fonts)
+        spanfont = getAvailableFont(spanfamily, pdf, additional_fonts, state)
 
     if 'font-weight' in spanstyle:
         try:
@@ -170,8 +172,9 @@ def AppendSpanEnd(paragraphText, weight, style, outerstyle):
 
 
 def AppendItemTextInStyle(paragraphText, text, item, pdf, additional_fonts, bodyfont, bodyfs,
-        bweight, bstyle, fontScaleFactor): # pylint: disable= too-many-arguments
-    pfont, pfs, pweight, pstyle = CollectFontInfo(item, pdf, additional_fonts, bodyfont, bodyfs, bweight, fontScaleFactor)
+        bweight, bstyle, fontScaleFactor, state: ConversionState): # pylint: disable= too-many-arguments
+    pfont, pfs, pweight, pstyle = CollectFontInfo(
+        item, pdf, additional_fonts, bodyfont, bodyfs, bweight, fontScaleFactor, state)
     paragraphText = AppendSpanStart(paragraphText, pfont, pfs, pweight, pstyle, bstyle)
     if text is None:
         paragraphText = AppendText(paragraphText, "")

--- a/textareas.py
+++ b/textareas.py
@@ -21,9 +21,9 @@ from lxml import etree
 from borders import processDecorationBorders
 from colorFrame import ColorFrame
 from colorUtils import ReorderColorBytesMcf2Rl
+from conversionState import ConversionState
 from fontHandling import getAvailableFont
 from index import Index
-from lineScales import LineScales
 from renderContext import RenderContext
 from shadows import warnAndIgnoreEnabledDecorationShadow
 from text import (AppendItemTextInStyle, AppendSpanEnd, AppendSpanStart, AppendText,
@@ -36,7 +36,7 @@ from textspacing import getLetterSpacing
 
 
 def processAreaTextTag(textTag, additional_fonts, area, areaWidth, areaHeight, areaRot, pdf, transCx, transCy,  # noqa: C901
-                       pgno, context: RenderContext, albumIndex):
+                       pgno, context: RenderContext, state: ConversionState, albumIndex):
     mcf2rl = context.mcf_to_reportlab
     # note: it would be better to use proper html processing here
 
@@ -194,7 +194,7 @@ def processAreaTextTag(textTag, additional_fonts, area, areaWidth, areaHeight, a
     except: # noqa: E722
         bodyfs = 12
     family = bstyle['font-family'].strip("'")
-    bodyfont = getAvailableFont(family, pdf, additional_fonts)
+    bodyfont = getAvailableFont(family, pdf, additional_fonts, state)
 
     try:
         bweight = int(Dequote(bstyle['font-weight']))
@@ -262,7 +262,7 @@ def processAreaTextTag(textTag, additional_fonts, area, areaWidth, areaHeight, a
     cwtextart = area.findall('decoration/cwtextart')
     if len(cwtextart) > 0:
         processTextArt(area, areaWidth, areaHeight, areaRot, pdf, transCx, transCy, body, leftPad, topPad,
-                       cwtextart, context)
+                       cwtextart, context, state)
         return
 
     pdf.translate(transCx, transCy)
@@ -322,13 +322,14 @@ def processAreaTextTag(textTag, additional_fonts, area, areaWidth, areaHeight, a
         # But, if we encounter the text wrapping issue, we will try again.
         pdf_flowableList = []
         # set default para style in case there are no spans to set it.
-        pdf_styleN = CreateParagraphStyle(reportlab.lib.colors.black, bodyfont, bodyfs, scaleFactor)
+        pdf_styleN = CreateParagraphStyle(
+            reportlab.lib.colors.black, bodyfont, bodyfs, scaleFactor, context.line_scales)
         pdf_styleN.textOutline = textOutline
         pdf_styleN.letterSpacing = letterSpacing
         textWrapProblem, indexEntryText, finalTotalHeight, frameBottomLeft_x, frameBottomLeft_y, frameHeight, frameWidth, recentText = \
             processTextCore(pdf_flowableList, pdf_styleN, None, additional_fonts, areaHeight, areaWidth,
                 body, bodyfont, bodyfs, bottomPad, bstyle, bweight, family, leftPad, pdf, rightPad, topPad, scaleFactor,
-                context, albumIndex)
+                context, state, albumIndex)
         if not textWrapProblem or iterationsToShrinkFontWhenNecessary == 0:
             if not textWrapProblem:
                 if scaleFactor < 1.0:
@@ -377,7 +378,8 @@ def processAreaTextTag(textTag, additional_fonts, area, areaWidth, areaHeight, a
 
             pdf_flowableList = [] # Throw away previous layout
             # set default para style in case there are no spans to set it.
-            pdf_styleN = CreateParagraphStyle(reportlab.lib.colors.black, bodyfont, bodyfs, scaleFactor)
+            pdf_styleN = CreateParagraphStyle(
+                reportlab.lib.colors.black, bodyfont, bodyfs, scaleFactor, context.line_scales)
             pdf_styleN.textOutline = textOutline
             pdf_styleN.letterSpacing = letterSpacing
             # use forceLeading=1.0 to force minimal leading.  Even with 1.0 there is generally a bit of spare points of space
@@ -385,7 +387,7 @@ def processAreaTextTag(textTag, additional_fonts, area, areaWidth, areaHeight, a
             # So we still need to do some padding adjustment below.
             textWrapProblem, indexEntryText, finalTotalHeight, frameBottomLeft_x, frameBottomLeft_y, frameHeight, frameWidth, recentText = \
                 processTextCore(pdf_flowableList, pdf_styleN, 1.0, additional_fonts, areaHeight, areaWidth, body, bodyfont, bodyfs,
-                bottomPad, bstyle, bweight, family, leftPad, pdf, rightPad, topPad, scaleFactor, context, albumIndex)
+                bottomPad, bstyle, bweight, family, leftPad, pdf, rightPad, topPad, scaleFactor, context, state, albumIndex)
 
             # Recalculate for the new height.
             emptySpace = originalFrameHeight - finalTotalHeight
@@ -463,14 +465,14 @@ def processAreaTextTag(textTag, additional_fonts, area, areaWidth, areaHeight, a
 
 
 def processTextArt(area, areaWidth, areaHeight, areaRot, pdf, transCx, transCy, body, leftPad, topPad,
-                   cwtextart, context: RenderContext):
+                   cwtextart, context: RenderContext, state: ConversionState):
     pdf.translate(transCx, transCy)
     pdf.rotate(-areaRot)
     for decorationTag in area.findall('decoration'):
         processDecorationBorders(decorationTag, areaHeight, areaWidth, pdf, context)
     bodyhtml = etree.tostring(body, pretty_print=True, encoding="unicode")
     radius = topPad - leftPad # is this really what they use for the radius?
-    handleTextArt(pdf, radius, bodyhtml, cwtextart)
+    handleTextArt(pdf, radius, bodyhtml, cwtextart, state)
     pdf.rotate(areaRot)
     pdf.translate(-transCx, -transCy)
 
@@ -478,7 +480,7 @@ def processTextArt(area, areaWidth, areaHeight, areaRot, pdf, transCx, transCy, 
 def processTextParas(pdf_flowableList, forceLeading, paragraphText: str, additional_fonts, body,  # noqa: C901
         bodyfont: str | Any, bodyfs: int, bstyle: dict[Any, Any], bweight: int,
         family, indexEntryText: Any | None, pdf, pdf_styleN, fontScaleFactor: float,
-        unprocessed_children: set[Any], albumIndex,
+        unprocessed_children: set[Any], albumIndex, line_scales, state: ConversionState,
         available_text_width: float) -> tuple[Any, str]:
     htmlparas = body.findall(".//p")
 
@@ -509,7 +511,7 @@ def processTextParas(pdf_flowableList, forceLeading, paragraphText: str, additio
                     hasExplicitLineHeight = True
                 except: # noqa: E722
                     logging.warning(f"Ignoring invalid paragraph line-height setting {pStyleAttribute}")
-        finalLeadingFactor = LineScales.lineScaleForFont(bodyfont) * pLineHeight
+        finalLeadingFactor = line_scales.lineScaleForFont(bodyfont) * pLineHeight
         # 100% is CEWE's normal layout and retains the established ReportLab
         # auto-leading behaviour.  For a user-selected percentage, however,
         # auto-leading would partly replace the requested leading with font
@@ -521,14 +523,14 @@ def processTextParas(pdf_flowableList, forceLeading, paragraphText: str, additio
             if forceLeading is not None:
                 return usefs * forceLeading
             if useExplicitLineHeight:
-                return LeadingForExplicitLineHeight(bodyfont, usefs, pLineHeight)
+                return LeadingForExplicitLineHeight(bodyfont, usefs, pLineHeight, line_scales)
             return usefs * finalLeadingFactor
 
         htmlspans = p.findall(".*")
         tabbed_text_line = getTabbedTextLine(
             p, pdf, additional_fonts, bodyfont, bodyfs, bweight, bstyle,
             fontScaleFactor, paragraphLeading(bodyfs * fontScaleFactor),
-            pdf_styleN.textOutline, pdf_styleN.letterSpacing)
+            state, pdf_styleN.textOutline, pdf_styleN.letterSpacing)
         if (tabbed_text_line is not None and
                 tabbed_text_line.wrap(available_text_width, 0)[0] <= available_text_width):
             # ReportLab's Paragraph has no real tab stops.  TabbedTextLine is
@@ -540,7 +542,7 @@ def processTextParas(pdf_flowableList, forceLeading, paragraphText: str, additio
         if len(htmlspans) < 1: # i.e. there are no spans, just a paragraph
             paragraphText = f'<para autoLeading="{autoLeading}">'
             paragraphText, maxfs = AppendItemTextInStyle(paragraphText, p.text, p, pdf,
-                additional_fonts, bodyfont, bodyfs, bweight, bstyle, fontScaleFactor)
+                additional_fonts, bodyfont, bodyfs, bweight, bstyle, fontScaleFactor, state)
             paragraphText += '</para>'
             usefs = maxfs if maxfs > 0 else bodyfs
             pdf_styleN.leading = paragraphLeading(usefs) # line spacing (text + leading)
@@ -557,7 +559,7 @@ def processTextParas(pdf_flowableList, forceLeading, paragraphText: str, additio
             # the first span just continues that leading text
             if p.text is not None:
                 paragraphText, maxfs = AppendItemTextInStyle(paragraphText, p.text, p, pdf,
-                    additional_fonts, bodyfont, bodyfs, bweight, bstyle, fontScaleFactor)
+                    additional_fonts, bodyfont, bodyfs, bweight, bstyle, fontScaleFactor, state)
                 usefs = maxfs if maxfs > 0 else bodyfs
                 pdf_styleN.leading = paragraphLeading(usefs)  # line spacing (text + leading)
 
@@ -574,12 +576,12 @@ def processTextParas(pdf_flowableList, forceLeading, paragraphText: str, additio
                     # start a new pdf para in the style of the para and add the tail text of this br item
                     paragraphText = f'<para autoLeading="{autoLeading}">'
                     paragraphText, maxfs = AppendItemTextInStyle(paragraphText, br.tail, p, pdf,
-                        additional_fonts, bodyfont, bodyfs, bweight, bstyle, fontScaleFactor)
+                        additional_fonts, bodyfont, bodyfs, bweight, bstyle, fontScaleFactor, state)
 
                 elif item.tag == 'span':
                     span = item
                     spanfont, spanfs, spanweight, spanstyle = CollectFontInfo(span, pdf, additional_fonts, bodyfont,
-                        bodyfs, bweight, fontScaleFactor)
+                        bodyfs, bweight, fontScaleFactor, state)
 
                     maxfs = max(maxfs, spanfs)
 
@@ -607,7 +609,7 @@ def processTextParas(pdf_flowableList, forceLeading, paragraphText: str, additio
                             # now add the tail text of each br in the span style
                             paragraphText, maxfs = AppendItemTextInStyle(paragraphText, br.tail, span, pdf,
                                 additional_fonts, bodyfont, bodyfs, bweight,
-                                bstyle, fontScaleFactor)
+                                bstyle, fontScaleFactor, state)
                     else:
                         paragraphText = AppendSpanEnd(paragraphText, spanweight, spanstyle, bstyle)
 
@@ -631,7 +633,7 @@ def processTextParas(pdf_flowableList, forceLeading, paragraphText: str, additio
 def processTextCore(pdf_flowableList, pdf_styleN, forceLeading, additional_fonts, areaHeight, areaWidth, body, bodyfont: str | Any, bodyfs: int,
                     bottomPad: float | int | Any, bstyle: dict[Any, Any], bweight: int, family,
                     leftPad: float | int | Any, pdf, rightPad: float | int | Any, topPad: float | int | Any,
-                    fontScaleFactor: float, context: RenderContext, albumIndex) -> \
+                    fontScaleFactor: float, context: RenderContext, state: ConversionState, albumIndex) -> \
         tuple[bool, str | Any, float | int | Any, float | Any, float | Any, float | Any, float | int | Any, str | Any]:
 
     mcf2rl = context.mcf_to_reportlab
@@ -658,10 +660,11 @@ def processTextCore(pdf_flowableList, pdf_styleN, forceLeading, additional_fonts
 
     indexEntryText, recentParagraphText = processTextParas(pdf_flowableList, forceLeading, recentParagraphText,
         additional_fonts, body, bodyfont, bodyfs, bstyle, bweight, family, indexEntryText, pdf, pdf_styleN,
-        fontScaleFactor, unprocessed_children, albumIndex, availableTextWidth)
+        fontScaleFactor, unprocessed_children, albumIndex, context.line_scales, state, availableTextWidth)
 
     recentParagraphText = processTextUL(pdf_flowableList, forceLeading, recentParagraphText, additional_fonts,
-        body, bodyfont, bodyfs, bstyle, bweight, pdf, pdf_styleN, fontScaleFactor, unprocessed_children)
+        body, bodyfont, bodyfs, bstyle, bweight, pdf, pdf_styleN, fontScaleFactor, unprocessed_children,
+        context.line_scales, state)
 
     # The <table> tag contains margin info, not actual content - mark it as processed
     table = body.find('table')
@@ -737,7 +740,8 @@ def processTextCore(pdf_flowableList, pdf_styleN, forceLeading, additional_fonts
 
 def processTextUL(pdf_flowableList, forceLeading, paragraphText: str, additional_fonts, body,  # noqa: C901
         bodyfont: str | Any, bodyfs: int, bstyle: dict[Any, Any], bweight: int, pdf,
-        pdf_styleN, fontScaleFactor: float, unprocessed_children: set[Any]) -> str:
+        pdf_styleN, fontScaleFactor: float, unprocessed_children: set[Any], line_scales,
+        state: ConversionState) -> str:
     # Process <ul> (unordered list) elements - bulleted lists
     htmllists = body.findall("ul")
 
@@ -781,7 +785,7 @@ def processTextUL(pdf_flowableList, forceLeading, paragraphText: str, additional
                         pLineHeight = floor(float(liStyle['line-height'].strip("%"))) / 100.0
                     except:  # noqa: E722
                         logging.warning(f"Ignoring invalid list item line-height setting {liStyleAttribute}")
-            finalLeadingFactor = LineScales.lineScaleForFont(bodyfont) * pLineHeight
+            finalLeadingFactor = line_scales.lineScaleForFont(bodyfont) * pLineHeight
 
             # Start paragraph - we'll add bullet inside the styled text
             paragraphText = '<para autoLeading="max">'
@@ -794,7 +798,7 @@ def processTextUL(pdf_flowableList, forceLeading, paragraphText: str, additional
                 # Prepend bullet to the text so it gets styled
                 bullet_plus_text = bullet_txt + (li.text if li.text is not None else "")
                 paragraphText, maxfs = AppendItemTextInStyle(paragraphText, bullet_plus_text, li, pdf,
-                                                             additional_fonts, bodyfont, bodyfs, bweight, bstyle, fontScaleFactor)
+                                                             additional_fonts, bodyfont, bodyfs, bweight, bstyle, fontScaleFactor, state)
                 paragraphText += '</para>'
                 usefs = maxfs if maxfs > 0 else bodyfs
                 list_styleN.leading = usefs * forceLeading if forceLeading is not None else usefs * finalLeadingFactor
@@ -803,9 +807,9 @@ def processTextUL(pdf_flowableList, forceLeading, paragraphText: str, additional
                 # List item with spans and other formatting
                 bullet_plus_text = bullet_txt + (li.text if li.text is not None else "")
                 paragraphText, maxfs = AppendItemTextInStyle(paragraphText, bullet_plus_text, li, pdf,
-                                                             additional_fonts, bodyfont, bodyfs, bweight, bstyle, fontScaleFactor)
+                                                             additional_fonts, bodyfont, bodyfs, bweight, bstyle, fontScaleFactor, state)
                 paragraphText, maxfs = AppendItemTextInStyle(paragraphText, bullet_plus_text, li, pdf,
-                                                             additional_fonts, bodyfont, bodyfs, bweight, bstyle, fontScaleFactor)
+                                                             additional_fonts, bodyfont, bodyfs, bweight, bstyle, fontScaleFactor, state)
                 usefs = maxfs if maxfs > 0 else bodyfs
                 list_styleN.leading = usefs * forceLeading if forceLeading is not None else usefs * finalLeadingFactor
 
@@ -819,12 +823,12 @@ def processTextUL(pdf_flowableList, forceLeading, paragraphText: str, additional
                         if br.tail:
                             paragraphText, maxfs = AppendItemTextInStyle(paragraphText, br.tail, li, pdf,
                                                                          additional_fonts, bodyfont, bodyfs, bweight,
-                                                                         bstyle, fontScaleFactor)
+                                                                         bstyle, fontScaleFactor, state)
 
                     elif item.tag == 'span':
                         span = item
                         spanfont, spanfs, spanweight, spanstyle = CollectFontInfo(span, pdf, additional_fonts, bodyfont,
-                                                                                  bodyfs, bweight, fontScaleFactor)
+                                                                                  bodyfs, bweight, fontScaleFactor, state)
 
                         maxfs = max(maxfs, spanfs)
 
@@ -842,7 +846,7 @@ def processTextUL(pdf_flowableList, forceLeading, paragraphText: str, additional
                                 if br.tail:
                                     paragraphText, maxfs = AppendItemTextInStyle(paragraphText, br.tail, span, pdf,
                                                                                  additional_fonts, bodyfont, bodyfs,
-                                                                                 bweight, bstyle, fontScaleFactor)
+                                                                                 bweight, bstyle, fontScaleFactor, state)
                         else:
                             paragraphText = AppendSpanEnd(paragraphText, spanweight, spanstyle, bstyle)
 

--- a/textareas.py
+++ b/textareas.py
@@ -23,7 +23,7 @@ from colorFrame import ColorFrame
 from colorUtils import ReorderColorBytesMcf2Rl
 from conversionState import ConversionState
 from fontHandling import getAvailableFont
-from index import Index
+from albumIndex import AlbumIndex
 from renderContext import RenderContext
 from shadows import warnAndIgnoreEnabledDecorationShadow
 from text import (AppendItemTextInStyle, AppendSpanEnd, AppendSpanStart, AppendText,
@@ -36,7 +36,7 @@ from textspacing import getLetterSpacing
 
 
 def processAreaTextTag(textTag, additional_fonts, area, areaWidth, areaHeight, areaRot, pdf, transCx, transCy,  # noqa: C901
-                       pgno, context: RenderContext, state: ConversionState):
+                       pgno, context: RenderContext, state: ConversionState, albumIndex: AlbumIndex):
     mcf2rl = context.mcf_to_reportlab
     # note: it would be better to use proper html processing here
 
@@ -329,7 +329,7 @@ def processAreaTextTag(textTag, additional_fonts, area, areaWidth, areaHeight, a
         textWrapProblem, indexEntryText, finalTotalHeight, frameBottomLeft_x, frameBottomLeft_y, frameHeight, frameWidth, recentText = \
             processTextCore(pdf_flowableList, pdf_styleN, None, additional_fonts, areaHeight, areaWidth,
                 body, bodyfont, bodyfs, bottomPad, bstyle, bweight, family, leftPad, pdf, rightPad, topPad, scaleFactor,
-                context, state)
+                context, state, albumIndex)
         if not textWrapProblem or iterationsToShrinkFontWhenNecessary == 0:
             if not textWrapProblem:
                 if scaleFactor < 1.0:
@@ -348,7 +348,7 @@ def processAreaTextTag(textTag, additional_fonts, area, areaWidth, areaHeight, a
 
     # Just add one index entry
     if indexEntryText:
-        state.album_index.AddIndexEntry(pgno, indexEntryText)
+        albumIndex.AddIndexEntry(pgno, indexEntryText)
 
     # Apply vertical centering if ALIGNVCENTER is specified. We previously set topPad and bottomPad
     # to zero. Now we have the actual text height, we can calculate the required padding to center
@@ -387,7 +387,7 @@ def processAreaTextTag(textTag, additional_fonts, area, areaWidth, areaHeight, a
             # So we still need to do some padding adjustment below.
             textWrapProblem, indexEntryText, finalTotalHeight, frameBottomLeft_x, frameBottomLeft_y, frameHeight, frameWidth, recentText = \
                 processTextCore(pdf_flowableList, pdf_styleN, 1.0, additional_fonts, areaHeight, areaWidth, body, bodyfont, bodyfs,
-                bottomPad, bstyle, bweight, family, leftPad, pdf, rightPad, topPad, scaleFactor, context, state)
+                bottomPad, bstyle, bweight, family, leftPad, pdf, rightPad, topPad, scaleFactor, context, state, albumIndex)
 
             # Recalculate for the new height.
             emptySpace = originalFrameHeight - finalTotalHeight
@@ -480,7 +480,7 @@ def processTextArt(area, areaWidth, areaHeight, areaRot, pdf, transCx, transCy, 
 def processTextParas(pdf_flowableList, forceLeading, paragraphText: str, additional_fonts, body,  # noqa: C901
         bodyfont: str | Any, bodyfs: int, bstyle: dict[Any, Any], bweight: int,
         family, indexEntryText: Any | None, pdf, pdf_styleN, fontScaleFactor: float,
-        unprocessed_children: set[Any], line_scales, state: ConversionState,
+        unprocessed_children: set[Any], line_scales, state: ConversionState, albumIndex: AlbumIndex,
         available_text_width: float) -> tuple[Any, str]:
     htmlparas = body.findall(".//p")
 
@@ -548,8 +548,8 @@ def processTextParas(pdf_flowableList, forceLeading, paragraphText: str, additio
             pdf_styleN.leading = paragraphLeading(usefs) # line spacing (text + leading)
             pdf_flowableList.append(TextEffectsParagraph(paragraphText, pdf_styleN))
             originalFont = CollectItemFontFamily(p, family)
-            if state.album_index.CheckForIndexEntry(originalFont, bodyfs):
-                indexEntryText = Index.AppendIndexText(indexEntryText, p.text)
+            if albumIndex.CheckForIndexEntry(originalFont, bodyfs):
+                indexEntryText = AlbumIndex.AppendIndexText(indexEntryText, p.text)
 
         else:
             paragraphText = f'<para autoLeading="{autoLeading}">'
@@ -590,8 +590,8 @@ def processTextParas(pdf_flowableList, forceLeading, paragraphText: str, additio
                     if span.text is not None:
                         paragraphText = AppendText(paragraphText, html.escape(span.text))
                         originalFont = CollectItemFontFamily(span, family)
-                        if state.album_index.CheckForIndexEntry(originalFont, spanfs):
-                            indexEntryText = Index.AppendIndexText(indexEntryText, span.text)
+                        if albumIndex.CheckForIndexEntry(originalFont, spanfs):
+                            indexEntryText = AlbumIndex.AppendIndexText(indexEntryText, span.text)
 
                     # there might be (one or more, or only one?) line break within the span.
                     brs = span.findall(".//br")
@@ -633,7 +633,7 @@ def processTextParas(pdf_flowableList, forceLeading, paragraphText: str, additio
 def processTextCore(pdf_flowableList, pdf_styleN, forceLeading, additional_fonts, areaHeight, areaWidth, body, bodyfont: str | Any, bodyfs: int,
                     bottomPad: float | int | Any, bstyle: dict[Any, Any], bweight: int, family,
                     leftPad: float | int | Any, pdf, rightPad: float | int | Any, topPad: float | int | Any,
-                    fontScaleFactor: float, context: RenderContext, state: ConversionState) -> \
+                    fontScaleFactor: float, context: RenderContext, state: ConversionState, albumIndex: AlbumIndex) -> \
         tuple[bool, str | Any, float | int | Any, float | Any, float | Any, float | Any, float | int | Any, str | Any]:
 
     mcf2rl = context.mcf_to_reportlab
@@ -660,7 +660,7 @@ def processTextCore(pdf_flowableList, pdf_styleN, forceLeading, additional_fonts
 
     indexEntryText, recentParagraphText = processTextParas(pdf_flowableList, forceLeading, recentParagraphText,
         additional_fonts, body, bodyfont, bodyfs, bstyle, bweight, family, indexEntryText, pdf, pdf_styleN,
-        fontScaleFactor, unprocessed_children, context.line_scales, state, availableTextWidth)
+        fontScaleFactor, unprocessed_children, context.line_scales, state, albumIndex, availableTextWidth)
 
     recentParagraphText = processTextUL(pdf_flowableList, forceLeading, recentParagraphText, additional_fonts,
         body, bodyfont, bodyfs, bstyle, bweight, pdf, pdf_styleN, fontScaleFactor, unprocessed_children,

--- a/textareas.py
+++ b/textareas.py
@@ -36,7 +36,7 @@ from textspacing import getLetterSpacing
 
 
 def processAreaTextTag(textTag, additional_fonts, area, areaWidth, areaHeight, areaRot, pdf, transCx, transCy,  # noqa: C901
-                       pgno, context: RenderContext, state: ConversionState, albumIndex):
+                       pgno, context: RenderContext, state: ConversionState):
     mcf2rl = context.mcf_to_reportlab
     # note: it would be better to use proper html processing here
 
@@ -329,7 +329,7 @@ def processAreaTextTag(textTag, additional_fonts, area, areaWidth, areaHeight, a
         textWrapProblem, indexEntryText, finalTotalHeight, frameBottomLeft_x, frameBottomLeft_y, frameHeight, frameWidth, recentText = \
             processTextCore(pdf_flowableList, pdf_styleN, None, additional_fonts, areaHeight, areaWidth,
                 body, bodyfont, bodyfs, bottomPad, bstyle, bweight, family, leftPad, pdf, rightPad, topPad, scaleFactor,
-                context, state, albumIndex)
+                context, state)
         if not textWrapProblem or iterationsToShrinkFontWhenNecessary == 0:
             if not textWrapProblem:
                 if scaleFactor < 1.0:
@@ -348,7 +348,7 @@ def processAreaTextTag(textTag, additional_fonts, area, areaWidth, areaHeight, a
 
     # Just add one index entry
     if indexEntryText:
-        albumIndex.AddIndexEntry(pgno, indexEntryText)
+        state.album_index.AddIndexEntry(pgno, indexEntryText)
 
     # Apply vertical centering if ALIGNVCENTER is specified. We previously set topPad and bottomPad
     # to zero. Now we have the actual text height, we can calculate the required padding to center
@@ -387,7 +387,7 @@ def processAreaTextTag(textTag, additional_fonts, area, areaWidth, areaHeight, a
             # So we still need to do some padding adjustment below.
             textWrapProblem, indexEntryText, finalTotalHeight, frameBottomLeft_x, frameBottomLeft_y, frameHeight, frameWidth, recentText = \
                 processTextCore(pdf_flowableList, pdf_styleN, 1.0, additional_fonts, areaHeight, areaWidth, body, bodyfont, bodyfs,
-                bottomPad, bstyle, bweight, family, leftPad, pdf, rightPad, topPad, scaleFactor, context, state, albumIndex)
+                bottomPad, bstyle, bweight, family, leftPad, pdf, rightPad, topPad, scaleFactor, context, state)
 
             # Recalculate for the new height.
             emptySpace = originalFrameHeight - finalTotalHeight
@@ -480,7 +480,7 @@ def processTextArt(area, areaWidth, areaHeight, areaRot, pdf, transCx, transCy, 
 def processTextParas(pdf_flowableList, forceLeading, paragraphText: str, additional_fonts, body,  # noqa: C901
         bodyfont: str | Any, bodyfs: int, bstyle: dict[Any, Any], bweight: int,
         family, indexEntryText: Any | None, pdf, pdf_styleN, fontScaleFactor: float,
-        unprocessed_children: set[Any], albumIndex, line_scales, state: ConversionState,
+        unprocessed_children: set[Any], line_scales, state: ConversionState,
         available_text_width: float) -> tuple[Any, str]:
     htmlparas = body.findall(".//p")
 
@@ -548,7 +548,7 @@ def processTextParas(pdf_flowableList, forceLeading, paragraphText: str, additio
             pdf_styleN.leading = paragraphLeading(usefs) # line spacing (text + leading)
             pdf_flowableList.append(TextEffectsParagraph(paragraphText, pdf_styleN))
             originalFont = CollectItemFontFamily(p, family)
-            if albumIndex.CheckForIndexEntry(originalFont, bodyfs):
+            if state.album_index.CheckForIndexEntry(originalFont, bodyfs):
                 indexEntryText = Index.AppendIndexText(indexEntryText, p.text)
 
         else:
@@ -590,7 +590,7 @@ def processTextParas(pdf_flowableList, forceLeading, paragraphText: str, additio
                     if span.text is not None:
                         paragraphText = AppendText(paragraphText, html.escape(span.text))
                         originalFont = CollectItemFontFamily(span, family)
-                        if albumIndex.CheckForIndexEntry(originalFont, spanfs):
+                        if state.album_index.CheckForIndexEntry(originalFont, spanfs):
                             indexEntryText = Index.AppendIndexText(indexEntryText, span.text)
 
                     # there might be (one or more, or only one?) line break within the span.
@@ -633,7 +633,7 @@ def processTextParas(pdf_flowableList, forceLeading, paragraphText: str, additio
 def processTextCore(pdf_flowableList, pdf_styleN, forceLeading, additional_fonts, areaHeight, areaWidth, body, bodyfont: str | Any, bodyfs: int,
                     bottomPad: float | int | Any, bstyle: dict[Any, Any], bweight: int, family,
                     leftPad: float | int | Any, pdf, rightPad: float | int | Any, topPad: float | int | Any,
-                    fontScaleFactor: float, context: RenderContext, state: ConversionState, albumIndex) -> \
+                    fontScaleFactor: float, context: RenderContext, state: ConversionState) -> \
         tuple[bool, str | Any, float | int | Any, float | Any, float | Any, float | Any, float | int | Any, str | Any]:
 
     mcf2rl = context.mcf_to_reportlab
@@ -660,7 +660,7 @@ def processTextCore(pdf_flowableList, pdf_styleN, forceLeading, additional_fonts
 
     indexEntryText, recentParagraphText = processTextParas(pdf_flowableList, forceLeading, recentParagraphText,
         additional_fonts, body, bodyfont, bodyfs, bstyle, bweight, family, indexEntryText, pdf, pdf_styleN,
-        fontScaleFactor, unprocessed_children, albumIndex, context.line_scales, state, availableTextWidth)
+        fontScaleFactor, unprocessed_children, context.line_scales, state, availableTextWidth)
 
     recentParagraphText = processTextUL(pdf_flowableList, forceLeading, recentParagraphText, additional_fonts,
         body, bodyfont, bodyfs, bstyle, bweight, pdf, pdf_styleN, fontScaleFactor, unprocessed_children,

--- a/textart.py
+++ b/textart.py
@@ -4,6 +4,7 @@ from reportlab.lib import colors
 from reportlab.pdfbase import pdfmetrics
 from bs4 import BeautifulSoup  # Import BeautifulSoup for HTML parsing
 from fontHandling import getMissingFontSubstitute
+from conversionState import ConversionState
 
 def parse_html_text(html):
     """Parses an HTML string, applying default styles from <body> while handling <p>, <span>, <i>, and <b>."""
@@ -71,7 +72,8 @@ def parse_html_text(html):
     return parsed_data, maxfontsize
 
 
-def processParsedText(parsed_text, pdf, originalRadius, start_angle_deg, clockwise, maxfontsize):
+def processParsedText(parsed_text, pdf, originalRadius, start_angle_deg, clockwise, maxfontsize,
+                      state: ConversionState):
     notifiedFontError = False
     cx, cy = (0,0) # center
     current_angle = start_angle_deg
@@ -95,7 +97,7 @@ def processParsedText(parsed_text, pdf, originalRadius, start_angle_deg, clockwi
             letter_width = pdfmetrics.stringWidth(char, full_font, font_size)
         except KeyError:
             fail_font = full_font
-            full_font = getMissingFontSubstitute(font_name) # honouring any configured font substitutions
+            full_font = getMissingFontSubstitute(font_name, state) # honouring any configured font substitutions
             if not notifiedFontError: # just one message per text art
                 logging.error(f"Unregistered font in TextArt: {fail_font}, font substitution: {full_font}")
                 notifiedFontError = True
@@ -140,7 +142,7 @@ def processParsedText(parsed_text, pdf, originalRadius, start_angle_deg, clockwi
     return angle_extent
 
 
-def draw_styled_text_on_arc(pdf, bodyhtml, radius, start_angle_deg, clockwise=True):
+def draw_styled_text_on_arc(pdf, bodyhtml, radius, start_angle_deg, state: ConversionState, clockwise=True):
     """
     Draws styled text along a circular arc, applying bold and italic styles dynamically.
     Parameters:
@@ -169,13 +171,13 @@ def draw_styled_text_on_arc(pdf, bodyhtml, radius, start_angle_deg, clockwise=Tr
     # that we can place it symmetrically around the given start angle
     givenStartAngle = 90 - start_angle_deg if clockwise else start_angle_deg - 90
     angularExtent = processParsedText(parsed_text, None, effectiveRadius, start_angle_deg,
-        clockwise, maxfontsize)
+        clockwise, maxfontsize, state)
     centredStartAngle = givenStartAngle - (angularExtent * 0.5)
 
-    processParsedText(parsed_text, pdf, effectiveRadius, centredStartAngle, clockwise, maxfontsize)
+    processParsedText(parsed_text, pdf, effectiveRadius, centredStartAngle, clockwise, maxfontsize, state)
 
 
-def handleTextArt(pdf, radius, bodyhtml, cwtextart):
+def handleTextArt(pdf, radius, bodyhtml, cwtextart, state: ConversionState):
     if "enabled" in cwtextart[0].attrib:
         enabledAttrib = cwtextart[0].get('enabled')
         if enabledAttrib != '1':
@@ -191,4 +193,4 @@ def handleTextArt(pdf, radius, bodyhtml, cwtextart):
         directionAttrib = cwtextart[0].get('direction')
         direction = directionAttrib == '1'
 
-    draw_styled_text_on_arc(pdf, bodyhtml, radius, widthAngle, clockwise=direction)
+    draw_styled_text_on_arc(pdf, bodyhtml, radius, widthAngle, state, clockwise=direction)

--- a/texttabs.py
+++ b/texttabs.py
@@ -24,6 +24,7 @@ from reportlab.pdfbase import pdfmetrics
 from reportlab.platypus import Flowable
 
 from text import CollectFontInfo, IsBold, IsItalic, IsUnderline
+from conversionState import ConversionState
 
 
 @dataclass(frozen=True)
@@ -113,7 +114,7 @@ class TabbedTextLine(Flowable):
 
 def getTabbedTextLine(paragraph, pdf, additional_fonts, body_font, body_size,
                       body_weight, body_style, font_scale_factor,
-                      leading, text_outline=None, letter_spacing=0.0):
+                      leading, state: ConversionState, text_outline=None, letter_spacing=0.0):
     """Return a direct-drawing flowable for a supported tabbed paragraph.
 
     ``None`` tells the caller to use the existing Paragraph implementation.
@@ -134,7 +135,7 @@ def getTabbedTextLine(paragraph, pdf, additional_fonts, body_font, body_size,
             return
         font, font_size, weight, item_style = CollectFontInfo(
             item, pdf, additional_fonts, body_font, body_size, body_weight,
-            font_scale_factor)
+            font_scale_factor, state)
         try:
             font_name = tt2ps(font, IsBold(weight),
                               IsItalic(item_style, body_style))


### PR DESCRIPTION
This change removes mutable, conversion-specific state from module scope and gives each `convertMcf()` call its own `ConversionState`. The change complements the earlier introduction of `RenderContext`, which carries the stable rendering resources and settings needed throughout conversion, such as unit conversion, image settings, clip-art paths, and line scales. `ConversionState `carries the corresponding mutable information created or discovered during one conversion. Together they make the distinction between conversion inputs and conversion-time state explicit, reducing hidden dependencies and making the rendering code easier to follow and maintain.

- The state now carries resources and information discovered while an album is rendered, including temporary files, lookup caches, font substitutions, and message counters. This prevents one conversion from influencing another when several albums are processed in the same Python process.
- The album index was deliberately kept separate from ConversionState: it is an optional text-processing feature, created and finalised by the top-level conversion, and passed explicitly only through the text-rendering path. Index has consequently been renamed to AlbumIndex.
- There should be no intended rendering change. The refactor makes ownership and lifetime of mutable data clearer, reduces hidden coupling, and provides a safer basis for future work such as repeated or parallel conversions. The full regression suite passes (40 tests).

