### PR TITLE
textlist handling to its own file, album conversion session, standard test import path

### DIFF
--- a/albumConversionSession.py
+++ b/albumConversionSession.py
@@ -1,0 +1,182 @@
+"""Managed lifetime of one CEWE album-to-PDF conversion."""
+
+# A session coordinates the whole conversion and therefore naturally carries
+# more construction data than a small rendering helper.  Keeping this data in
+# one named object makes the ownership and cleanup boundary explicit.
+# pylint: disable=too-many-arguments,too-many-instance-attributes
+
+from functools import partial
+import gc
+import logging
+import os
+import sys
+
+import reportlab.lib.pagesizes
+from reportlab.pdfgen import canvas
+
+from albumIndex import AlbumIndex
+from ceweInfo import AlbumInfo, CeweInfo, ProductStyle
+from conversionSetup import prepareConversion
+from conversionState import ConversionState
+from extraLoggers import ConversionMessageCounters
+from pageNumbering import PageNumberingInfo
+from pages import processPages
+from renderContext import RenderContext
+from versionInfo import logVersionInformation
+
+
+class AlbumConversionSession:
+    """Own one conversion's resources from validation through cleanup.
+
+    Use this as a context manager.  :meth:`render` creates and saves the PDF;
+    leaving the context releases temporary images and unpacked MCFX data even
+    when the conversion exits early.
+    """
+
+    def __init__(self, albumName, keepDoublePages, pageNumbers, mcfxTmpDir,
+                 appDataDir, outputFileName, mcfToReportlab, imageQuality,
+                 pilAntialias):
+        self.album_name = albumName
+        self.keep_double_pages = keepDoublePages
+        self.page_numbers = pageNumbers
+        self.mcfx_tmp_dir = mcfxTmpDir
+        self.app_data_dir = appDataDir
+        self.output_file_name = outputFileName
+        self.mcf_to_reportlab = mcfToReportlab
+        self.image_quality = imageQuality
+        self.pil_antialias = pilAntialias
+
+        self.state = ConversionState()
+        self.state.message_counters = ConversionMessageCounters()
+        self.setup = None
+
+    def __enter__(self):
+        logVersionInformation()
+        if self.output_file_name is None:
+            self.output_file_name = CeweInfo.getOutputFileName(self.album_name)
+        CeweInfo.ensureAcceptableOutputFile(self.output_file_name)
+        return self
+
+    def __exit__(self, exceptionType, exceptionValue, traceback):
+        """Report diagnostics and release files owned by this session."""
+        objectsCollected = gc.collect()
+        logging.info(f'GC collected objects : {objectsCollected}')
+
+        messageCounters = self.state.message_counters
+        if messageCounters is not None:
+            messageCounters.print_summary()
+            if self.setup is not None:
+                messageCounters.verify(self.setup.default_config_section)
+            messageCounters.close()
+
+        unpackedFolder = self.setup.unpacked_folder if self.setup is not None else None
+        cleanUpTemporaryFiles(self.state.temporary_files, unpackedFolder)
+        return False
+
+    def render(self, processElements):  # noqa: C901
+        """Prepare the album, render its pages, and save its primary PDF."""
+        self.setup = prepareConversion(
+            self.album_name, self.mcfx_tmp_dir, self.app_data_dir, self.state)
+        albumIndex = self._createAlbumIndex()
+
+        articleConfigElement = self.setup.fotobook.find('articleConfig')
+        if articleConfigElement is None:
+            logging.error(
+                f'{self.album_name} is an old version. Open it in the album editor '
+                'and save before retrying the pdf conversion. Exiting.')
+            sys.exit(1)
+
+        pageSize, productStyle = self._getProductDetails()
+        pageCount = self._getPageCount(articleConfigElement, productStyle)
+        imageFolder = self.setup.fotobook.get('imagedir')
+        renderContext = RenderContext(
+            self.mcf_to_reportlab, self.setup.image_resolution, self.image_quality,
+            self.setup.background_resolution, self.pil_antialias,
+            self.setup.default_config_section, self.setup.clipart_files,
+            self.setup.clipart_paths, self.setup.passepartout_folders,
+            self.setup.line_scales)
+
+        pdf = canvas.Canvas(self.output_file_name, pagesize=pageSize)
+        pdf.setTitle(self.setup.album_title)
+        pageNumberingInfo = self._createPageNumberingInfo(pdf)
+        processElementsForAlbum = partial(
+            processElements, state=self.state, albumIndex=albumIndex)
+
+        processPages(
+            self.setup.fotobook, self.setup.mcf_base_folder, imageFolder,
+            productStyle, pdf, pageCount, self.page_numbers, self.setup.cewe_folder,
+            self.setup.available_fonts, self.setup.background_locations, self.state,
+            renderContext, pageNumberingInfo, processElementsForAlbum)
+
+        try:
+            pdf.save()
+        except Exception as exception:  # pylint: disable=broad-exception-caught
+            logging.error(f'Could not save the output file: {str(exception)}')
+
+        self._createIndexOutput(albumIndex, pageSize)
+        if productStyle == ProductStyle.MemoryCard:
+            print()
+            print('Use Adobe Acrobat to print the memory cards. Set custom pages per sheet, 4 wide x 6 down')
+            print(' and print two copies!')
+        return True
+
+    def _createAlbumIndex(self):
+        if self.setup.configuration is None:
+            return AlbumIndex(None)
+        try:
+            return AlbumIndex(self.setup.configuration['INDEX'])
+        except KeyError:
+            return AlbumIndex(None)
+
+    def _getProductDetails(self):
+        pageSize = reportlab.lib.pagesizes.A4
+        productStyle = ProductStyle.AlbumSingleSide
+        productName = self.setup.fotobook.get('productname')
+        if productName in AlbumInfo.formats:
+            pageSize = AlbumInfo.formats[productName]
+        if productName in AlbumInfo.styles:
+            productStyle = AlbumInfo.styles[productName]
+        if self.keep_double_pages:
+            if productStyle == ProductStyle.AlbumSingleSide:
+                productStyle = ProductStyle.AlbumDoubleSide
+            elif productStyle == ProductStyle.MemoryCard:
+                logging.warning('keepdoublepages option is irrelevant and ignored for a memory card product')
+        return pageSize, productStyle
+
+    @staticmethod
+    def _getPageCount(articleConfigElement, productStyle):
+        if AlbumInfo.isAlbumProduct(productStyle):
+            # Albums record only usable inside pages in normalpages. The two
+            # outer covers make the corresponding single-sided PDF page count.
+            return int(articleConfigElement.get('normalpages')) + 2
+        # Photo Pairs records each card as a real MCF page; it has neither
+        # covers nor two-page bundles, so do not apply the album +2 rule.
+        return int(articleConfigElement.get('totalpages'))
+
+    def _createPageNumberingInfo(self, pdf):
+        pageNumberElement = self.setup.fotobook.find('pagenumbering')
+        if pageNumberElement is None or int(pageNumberElement.get('position')) == 0:
+            return None
+        return PageNumberingInfo(
+            pageNumberElement, pdf, self.setup.available_fonts, self.state)
+
+    def _createIndexOutput(self, albumIndex, pageSize):
+        if not albumIndex.indexing:
+            return
+        indexPdfFileName = albumIndex.SaveIndexPdf(
+            self.output_file_name, self.setup.album_title, pageSize)
+        indexPngFileName = albumIndex.SaveIndexPng(indexPdfFileName)
+        albumIndex.MergeAlbumAndIndexPng(self.output_file_name, indexPngFileName)
+        if albumIndex.deleteIndexPdf and os.path.exists(indexPdfFileName):
+            os.remove(indexPdfFileName)
+        if albumIndex.deleteIndexPng and os.path.exists(indexPngFileName):
+            os.remove(indexPngFileName)
+
+
+def cleanUpTemporaryFiles(fileList, unpackedFolder):
+    """Remove temporary images and unpacked MCFX data owned by a session."""
+    for temporaryFileName in fileList:
+        if os.path.exists(temporaryFileName):
+            os.remove(temporaryFileName)
+    if unpackedFolder is not None:
+        unpackedFolder.cleanup()

--- a/cewe2pdf.py
+++ b/cewe2pdf.py
@@ -57,7 +57,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # only needed when the program is frozen (i.e. compiled).
 import sys
 
-from versionInfo import getVersionInformationText, logVersionInformation
+from versionInfo import getVersionInformationText
 
 # Let a user identify an executable without loading image libraries or reading
 # any album files.  argparse also knows about --version below for its help.
@@ -75,34 +75,27 @@ import logging.config
 import os.path
 import os
 
-import gc
-
 import argparse  # to parse arguments
-from functools import partial
 from math import floor
 
 import reportlab.lib.pagesizes
-from reportlab.pdfgen import canvas
 # from reportlab.pdfbase.pdfmetrics import stringWidth as _stringWidth
 # from reportlab.lib.styles import getSampleStyleSheet
 
 import PIL
 
 from packaging.version import parse as parse_version
-from ceweInfo import CeweInfo, AlbumInfo, ProductStyle
+from ceweInfo import AlbumInfo
+from albumIndex import AlbumIndex
 from borders import processDecorationBorders
 from clipartareas import processAreaClipartTag
-from conversionSetup import prepareConversion
 from conversionState import ConversionState
-from extraLoggers import ConversionMessageCounters
 from imageareas import processAreaImageTag
-from pageNumbering import PageNumberingInfo
 from pageTypes import PageProcessingType
 from cewePageResolver import getPageElementForPageNumber
-from pages import processPages
 from renderContext import RenderContext
 from textareas import processAreaTextTag
-from albumIndex import AlbumIndex
+from albumConversionSession import AlbumConversionSession
 from shadows import processDecorationShadow
 
 
@@ -148,6 +141,7 @@ image_quality = 86  # 0=worst, 100=best. This is the JPEG quality option.
 # Keep this conversion at the boundary: area-rendering modules receive it in
 # RenderContext rather than each maintaining its own approximation.
 mcf2rl = reportlab.lib.pagesizes.mm/10 # == 72/254, converts from mcf (unit=0.1mm) to reportlab (unit=inch/72)
+
 
 # `pages.processPages` identifies the correct MCF page element, including the
 # slightly unusual cover and paired-page rules. This callback dispatches each
@@ -219,124 +213,15 @@ def processElements(additional_fonts, fotobook, imagedir,
                                       processDecorationBorders(decoration, height, width, canvas, context))
     return
 
-def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=None, appDataDir=None, outputFileName=None): # noqa: C901 (too complex)
-    conversionState = ConversionState()
-    conversionState.message_counters = ConversionMessageCounters()
-    logVersionInformation()
-    pageNumberingInfo = None
 
-    # check output file is acceptable before we do any processing, which is
-    # preferable to processing for a long time and *then* discovering that
-    # the file is not writable
-    if outputFileName is None:
-        outputFileName = CeweInfo.getOutputFileName(albumname)
-    CeweInfo.ensureAcceptableOutputFile(outputFileName)
+def convertMcf(albumname, keepDoublePages: bool, pageNumbers=None, mcfxTmpDir=None,
+               appDataDir=None, outputFileName=None):
+    """Convert one MCF or MCFX album while preserving the established API."""
+    with AlbumConversionSession(
+            albumname, keepDoublePages, pageNumbers, mcfxTmpDir, appDataDir,
+            outputFileName, mcf2rl, image_quality, pil_antialias) as session:
+        return session.render(processElements)
 
-    setup = prepareConversion(albumname, mcfxTmpDir, appDataDir, conversionState)
-
-    if setup.configuration is None:
-        albumIndex = AlbumIndex(None)
-    else:
-        try:
-            albumIndex = AlbumIndex(setup.configuration['INDEX'])
-        except KeyError:
-            albumIndex = AlbumIndex(None)
-
-    # extract basic album properties
-    articleConfigElement = setup.fotobook.find('articleConfig')
-    if articleConfigElement is None:
-        logging.error(f'{albumname} is an old version. Open it in the album editor and save before retrying the pdf conversion. Exiting.')
-        sys.exit(1)
-
-    # find the correct size for the album format (if we know!) and set the product style
-    pagesize = reportlab.lib.pagesizes.A4
-    productstyle = ProductStyle.AlbumSingleSide
-    productname = setup.fotobook.get('productname')
-    if productname in AlbumInfo.formats: # IMO this is clearest so pylint: disable=consider-using-get
-        pagesize = AlbumInfo.formats[productname]
-    if productname in AlbumInfo.styles: # IMO this is clearest so pylint: disable=consider-using-get
-        productstyle = AlbumInfo.styles[productname]
-    if keepDoublePages:
-        if productstyle == ProductStyle.AlbumSingleSide:
-            productstyle = ProductStyle.AlbumDoubleSide
-        elif productstyle == ProductStyle.MemoryCard:
-            logging.warning('keepdoublepages option is irrelevant and ignored for a memory card product')
-
-    if AlbumInfo.isAlbumProduct(productstyle):
-        pageCount = int(articleConfigElement.get('normalpages')) + 2
-        # Albums record only usable inside pages in normalpages. The two outer
-        # covers make the corresponding single-sided PDF page count.
-    else:
-        # Photo Pairs records each card as a real MCF page; it has neither
-        # covers nor two-page bundles, so do not apply the album +2 rule.
-        pageCount = int(articleConfigElement.get('totalpages'))
-
-    imageFolder = setup.fotobook.get('imagedir')
-    renderContext = RenderContext(mcf2rl, setup.image_resolution, image_quality, setup.background_resolution,
-                                  pil_antialias, setup.default_config_section, setup.clipart_files,
-                                  setup.clipart_paths, setup.passepartout_folders, setup.line_scales)
-
-    # initialize a pdf canvas
-    pdf = canvas.Canvas(outputFileName, pagesize=pagesize)
-    pdf.setTitle(setup.album_title)
-
-    pageNumberElement = setup.fotobook.find('pagenumbering')
-    if pageNumberElement is not None:
-        pnpos = int(pageNumberElement.get('position'))
-        if pnpos != 0: # 0 implies no numbering
-            # make a page number description object to use later
-            pageNumberingInfo = PageNumberingInfo(pageNumberElement, pdf, setup.available_fonts, conversionState)
-    # processPages calls its element-rendering callback with the normal page
-    # arguments plus renderContext.  partial() creates an equivalent callback
-    # The index is an optional text-processing feature.  Passing it explicitly
-    # keeps it outside the general rendering state used by every area type.
-    processElementsForAlbum = partial(processElements, state=conversionState, albumIndex=albumIndex)
-
-    # `pages` owns CEWE's page/cover selection. It calls our callback for the
-    # actual areas once the canvas has been sized and the background drawn.
-    processPages(setup.fotobook, setup.mcf_base_folder, imageFolder, productstyle, pdf, pageCount, pageNumbers,
-        setup.cewe_folder, setup.available_fonts, setup.background_locations, conversionState, renderContext,
-        pageNumberingInfo, processElementsForAlbum)
-
-    # save final output pdf
-    try:
-        pdf.save()
-    except Exception as ex:
-        logging.error(f'Could not save the output file: {str(ex)}')
-
-    pdf = []
-
-    if albumIndex.indexing:
-        # At this point we have an index of items (selected on the basis of their font characteristics)
-        #   albumIndex.ShowIndex()
-        indexPdfFileName = albumIndex.SaveIndexPdf(outputFileName, setup.album_title, pagesize)
-        indexPngFileName = albumIndex.SaveIndexPng(indexPdfFileName)
-        albumIndex.MergeAlbumAndIndexPng(outputFileName, indexPngFileName)
-        # most usual is to delete the index pdf, but leave the index png which could be added
-        # to the original with the cewe editor, and then you get it in the printed edition as well
-        if albumIndex.deleteIndexPdf and os.path.exists(indexPdfFileName):
-            os.remove(indexPdfFileName)
-        if albumIndex.deleteIndexPng and os.path.exists(indexPngFileName):
-            os.remove(indexPngFileName)
-
-    # force the release of objects which might be holding on to picture file references
-    # so that they will not prevent the removal of the files as we clean up and exit
-    objectscollected = gc.collect()
-    logging.info(f'GC collected objects : {objectscollected}')
-
-    conversionState.message_counters.print_summary()
-
-    if productstyle == ProductStyle.MemoryCard:
-        print()
-        print("Use Adobe Acrobat to print the memory cards. Set custom pages per sheet, 4 wide x 6 down")
-        print(" and print two copies!")
-
-    conversionState.message_counters.verify(setup.default_config_section)
-
-    cleanUpTempFiles(conversionState.temporary_files, setup.unpacked_folder)
-    conversionState.message_counters.close()
-
-    return True
 
 def collectArgsAndConvert():
     class CustomArgFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
@@ -422,14 +307,6 @@ def collectArgsAndConvert():
 
     # convert the file
     return convertMcf(args.inputFile, args.keepDoublePages, pages, mcfxTmp, appData, outputFileName=outFile)
-
-
-def cleanUpTempFiles(fileList, unpackedFolder):
-    for tmpFileName in fileList:
-        if os.path.exists(tmpFileName):
-            os.remove(tmpFileName)
-    if unpackedFolder is not None:
-        unpackedFolder.cleanup()
 
 
 if __name__ == '__main__':

--- a/cewe2pdf.pyproj
+++ b/cewe2pdf.pyproj
@@ -319,6 +319,7 @@
     <Content Include="tests\unittest_fotobook\unittest_fotobook_mcf-Dateien\img6.png" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="albumConversionSession.py" />
     <Compile Include="backgrounds.py" />
     <Compile Include="borders.py" />
     <Compile Include="ceweInfo.py">

--- a/cewe2pdf.pyproj
+++ b/cewe2pdf.pyproj
@@ -407,6 +407,7 @@
     </Compile>
     <Compile Include="textareas.py" />
     <Compile Include="textart.py" />
+    <Compile Include="textlists.py" />
     <Compile Include="textoutlines.py" />
     <Compile Include="textspacing.py" />
     <Compile Include="texttabs.py" />

--- a/tests/testCewePageResolver/test_cewePageResolver.py
+++ b/tests/testCewePageResolver/test_cewePageResolver.py
@@ -10,6 +10,8 @@ from lxml import etree
 # including GitHub Actions' test-collection environment.
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(PROJECT_ROOT))
+from testutils import configureTestImportPaths
+configureTestImportPaths(__file__)
 
 from ceweInfo import ProductStyle
 from cewePageResolver import resolvePages

--- a/tests/testClipart/test_drawClipart.py
+++ b/tests/testClipart/test_drawClipart.py
@@ -8,15 +8,15 @@
 
 # Test the clipart rendering
 
-#if you run this file directly, it won't have access to parent folder, so add it to python path
+# Bootstrap the project root so this test can also run directly.
 import os, os.path
 import sys
-sys.path.append('..')
-sys.path.append('.')
-sys.path.append('tests/compare-pdf/compare_pdf') # used if compare_pdf has not been pip installed
-
-from datetime import datetime
 from pathlib import Path
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+from testutils import configureTestImportPaths
+configureTestImportPaths(__file__)
+from datetime import datetime
 from pikepdf import Pdf, PdfImage
 
 from compare_pdf import ComparePDF, ShowDiffsStyle # type: ignore

--- a/tests/testClipartColorReplacement/test_clipartColorReplacement.py
+++ b/tests/testClipartColorReplacement/test_clipartColorReplacement.py
@@ -3,15 +3,15 @@
 
 # Test the clipart rendering with passepartout frame recoloring
 
-#if you run this file directly, it won't have access to parent folder, so add it to python path
+# Bootstrap the project root so this test can also run directly.
 import os, os.path
 import sys
-sys.path.append('..')
-sys.path.append('.')
-sys.path.append('tests/compare-pdf/compare_pdf') # used if compare_pdf has not been pip installed
-
-from datetime import datetime
 from pathlib import Path
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+from testutils import configureTestImportPaths
+configureTestImportPaths(__file__)
+from datetime import datetime
 from pikepdf import Pdf
 
 from compare_pdf import ComparePDF, ShowDiffsStyle # type: ignore

--- a/tests/testCorners/test_corners.py
+++ b/tests/testCorners/test_corners.py
@@ -3,15 +3,15 @@
 
 # Test the corner masking
 
-#if you run this file directly, it won't have access to parent folder, so add it to python path
+# Bootstrap the project root so this test can also run directly.
 import os, os.path
 import sys
-sys.path.append('..')
-sys.path.append('.')
-sys.path.append('tests/compare-pdf/compare_pdf') # used if compare_pdf has not been pip installed
-
-from datetime import datetime
 from pathlib import Path
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+from testutils import configureTestImportPaths
+configureTestImportPaths(__file__)
+from datetime import datetime
 from xml.etree import ElementTree
 from PIL import Image
 from pikepdf import Pdf, PdfImage

--- a/tests/testDecorations/test_decorations.py
+++ b/tests/testDecorations/test_decorations.py
@@ -3,19 +3,19 @@
 
 # Test of various object decorations
 
-#if you run this file directly, it won't have access to parent folder, so add it to python path
+# Bootstrap the project root so this test can also run directly.
 import os, os.path
 import sys
-sys.path.append('..')
-sys.path.append('.')
-sys.path.append('tests/compare-pdf/compare_pdf') # used if compare_pdf has not been pip installed
-
+from pathlib import Path
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+from testutils import configureTestImportPaths
+configureTestImportPaths(__file__)
 # Parse the mcf file to create variations using xml.dom.minidom rather than xml.etree.ElementTree
 # Copilot suggested this choice because etree is bad at parsing CDATA
 from xml.dom.minidom import parse, Document
 
 from datetime import datetime
-from pathlib import Path
 from pikepdf import Pdf
 
 from compare_pdf import ComparePDF, ShowDiffsStyle # type: ignore

--- a/tests/testEmptyPageOne/test_emptyPageOne.py
+++ b/tests/testEmptyPageOne/test_emptyPageOne.py
@@ -3,15 +3,15 @@
 
 # Test rendering when page one is empty
 
-#if you run this file directly, it won't have access to parent folder, so add it to python path
+# Bootstrap the project root so this test can also run directly.
 import os, os.path
 import sys
-sys.path.append('..')
-sys.path.append('.')
-sys.path.append('tests/compare-pdf/compare_pdf') # used if compare_pdf has not been pip installed
-
-from datetime import datetime
 from pathlib import Path
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+from testutils import configureTestImportPaths
+configureTestImportPaths(__file__)
+from datetime import datetime
 from pikepdf import Pdf
 
 from compare_pdf import ComparePDF, ShowDiffsStyle # type: ignore

--- a/tests/testFontDoesNotExist/test_fontDoesNotExist.py
+++ b/tests/testFontDoesNotExist/test_fontDoesNotExist.py
@@ -9,11 +9,13 @@
 # test what happens when a font file does not exist.
 # if the font is missing, the page where it was used should still exist.
 
-#if you run this file directly, it won't have access to parent folder, so add it to python path
+# Bootstrap the project root so this test can also run directly.
 import sys
-sys.path.append('..')
-sys.path.append('.')
 from pathlib import Path
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+from testutils import configureTestImportPaths
+configureTestImportPaths(__file__)
 import os, os.path
 from pikepdf import Pdf
 

--- a/tests/testFontSubstitution/test_fontSubstitution.py
+++ b/tests/testFontSubstitution/test_fontSubstitution.py
@@ -3,15 +3,15 @@
 
 # Test the default substitution for missing fonts
 
-#if you run this file directly, it won't have access to parent folder, so add it to python path
+# Bootstrap the project root so this test can also run directly.
 import os, os.path
 import sys
-sys.path.append('..')
-sys.path.append('.')
-sys.path.append('tests/compare-pdf/compare_pdf') # used if compare_pdf has not been pip installed
-
-from datetime import datetime
 from pathlib import Path
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+from testutils import configureTestImportPaths
+configureTestImportPaths(__file__)
+from datetime import datetime
 from pikepdf import Pdf
 
 from compare_pdf import ComparePDF, ShowDiffsStyle # type: ignore

--- a/tests/testIndex/test_index.py
+++ b/tests/testIndex/test_index.py
@@ -3,21 +3,21 @@
 
 # Test rendering when page one is empty
 
-#if you run this file directly, it won't have access to parent folder, so add it to python path
+# Bootstrap the project root so this test can also run directly.
 import os, os.path
 import sys
+from pathlib import Path
 
 from numpy import test
-sys.path.append('..')
-sys.path.append('.')
-sys.path.append('tests/compare-pdf/compare_pdf') # used if compare_pdf has not been pip installed
-
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+from testutils import configureTestImportPaths
+configureTestImportPaths(__file__)
 # Parse the mcf file to create variations using xml.dom.minidom rather than xml.etree.ElementTree
 # Copilot suggested this choice because etree is bad at parsing CDATA
 from xml.dom.minidom import parse, Document
 
 from datetime import datetime
-from pathlib import Path
 from pikepdf import Pdf
 
 from compare_pdf import ComparePDF, ShowDiffsStyle # type: ignore

--- a/tests/testIndexLarge/test_indexLarge.py
+++ b/tests/testIndexLarge/test_indexLarge.py
@@ -3,21 +3,21 @@
 
 # Test rendering when page one is empty
 
-#if you run this file directly, it won't have access to parent folder, so add it to python path
+# Bootstrap the project root so this test can also run directly.
 import os, os.path
 import sys
+from pathlib import Path
 
 from numpy import test
-sys.path.append('..')
-sys.path.append('.')
-sys.path.append('tests/compare-pdf/compare_pdf') # used if compare_pdf has not been pip installed
-
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+from testutils import configureTestImportPaths
+configureTestImportPaths(__file__)
 # Parse the mcf file to create variations using xml.dom.minidom rather than xml.etree.ElementTree
 # Copilot suggested this choice because etree is bad at parsing CDATA
 from xml.dom.minidom import parse, Document
 
 from datetime import datetime
-from pathlib import Path
 from pikepdf import Pdf
 
 from compare_pdf import ComparePDF, ShowDiffsStyle # type: ignore

--- a/tests/testLetterSpacing/test_letterSpacing.py
+++ b/tests/testLetterSpacing/test_letterSpacing.py
@@ -2,13 +2,13 @@
 
 import os
 import sys
-from datetime import datetime
 from pathlib import Path
+from datetime import datetime
 
-sys.path.append('..')
-sys.path.append('.')
-sys.path.append('tests/compare-pdf/compare_pdf')
-
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+from testutils import configureTestImportPaths
+configureTestImportPaths(__file__)
 from pikepdf import Pdf
 
 from compare_pdf import ComparePDF, ShowDiffsStyle  # type: ignore

--- a/tests/testLineHeight/test_lineHeight.py
+++ b/tests/testLineHeight/test_lineHeight.py
@@ -3,15 +3,15 @@
 
 # Test the default substitution for missing fonts
 
-#if you run this file directly, it won't have access to parent folder, so add it to python path
+# Bootstrap the project root so this test can also run directly.
 import os, os.path
 import sys
-sys.path.append('..')
-sys.path.append('.')
-sys.path.append('tests/compare-pdf/compare_pdf') # used if compare_pdf has not been pip installed
-
-from datetime import datetime
 from pathlib import Path
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+from testutils import configureTestImportPaths
+configureTestImportPaths(__file__)
+from datetime import datetime
 from pikepdf import Pdf
 
 from compare_pdf import ComparePDF, ShowDiffsStyle # type: ignore

--- a/tests/testLists/test_lists.py
+++ b/tests/testLists/test_lists.py
@@ -3,15 +3,15 @@
 
 # Test the default substitution for missing fonts
 
-#if you run this file directly, it won't have access to parent folder, so add it to python path
+# Bootstrap the project root so this test can also run directly.
 import os, os.path
 import sys
-sys.path.append('..')
-sys.path.append('.')
-sys.path.append('tests/compare-pdf/compare_pdf') # used if compare_pdf has not been pip installed
-
-from datetime import datetime
 from pathlib import Path
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+from testutils import configureTestImportPaths
+configureTestImportPaths(__file__)
+from datetime import datetime
 from pikepdf import Pdf
 
 from compare_pdf import ComparePDF, ShowDiffsStyle # type: ignore

--- a/tests/testMcfxExtraction/test_McfxExtraction.py
+++ b/tests/testMcfxExtraction/test_McfxExtraction.py
@@ -5,11 +5,13 @@
 
 # Test the unpacking of a .mcfx file to a .mcf file and the associated image files
 
-#if you run this file directly, it won't have access to parent folder, so add it to python path
+# Bootstrap the project root so this test can also run directly.
 import sys
-sys.path.append('..')
-sys.path.append('.')
 from pathlib import Path
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+from testutils import configureTestImportPaths
+configureTestImportPaths(__file__)
 import os, os.path
 import filecmp
 import logging

--- a/tests/testMemoryCards/test_memoryCards.py
+++ b/tests/testMemoryCards/test_memoryCards.py
@@ -4,15 +4,15 @@
 # Test conversion of CEWE Photo Pairs (MEM3) memory-card albums.
 # This is the one non-album product currently supported.
 
-#if you run this file directly, it won't have access to parent folder, so add it to python path
+# Bootstrap the project root so this test can also run directly.
 import os, os.path
 import sys
-sys.path.append('..')
-sys.path.append('.')
-sys.path.append('tests/compare-pdf/compare_pdf') # used if compare_pdf has not been pip installed
-
-from datetime import datetime
 from pathlib import Path
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+from testutils import configureTestImportPaths
+configureTestImportPaths(__file__)
+from datetime import datetime
 from xml.etree import ElementTree
 from PIL import Image
 from pikepdf import Pdf, PdfImage

--- a/tests/testPageNumbers/test_pagenumbers.py
+++ b/tests/testPageNumbers/test_pagenumbers.py
@@ -3,19 +3,19 @@
 
 # Test rendering when page one is empty
 
-#if you run this file directly, it won't have access to parent folder, so add it to python path
+# Bootstrap the project root so this test can also run directly.
 import os, os.path
 import sys
-sys.path.append('..')
-sys.path.append('.')
-sys.path.append('tests/compare-pdf/compare_pdf') # used if compare_pdf has not been pip installed
-
+from pathlib import Path
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+from testutils import configureTestImportPaths
+configureTestImportPaths(__file__)
 # Parse the mcf file to create variations using xml.dom.minidom rather than xml.etree.ElementTree
 # Copilot suggested this choice because etree is bad at parsing CDATA
 from xml.dom.minidom import parse, Document
 
 from datetime import datetime
-from pathlib import Path
 from pikepdf import Pdf
 
 from compare_pdf import ComparePDF, ShowDiffsStyle # type: ignore

--- a/tests/testShadows/test_shadows.py
+++ b/tests/testShadows/test_shadows.py
@@ -3,19 +3,19 @@
 
 # Test of various object shadows
 
-#if you run this file directly, it won't have access to parent folder, so add it to python path
+# Bootstrap the project root so this test can also run directly.
 import os, os.path
 import sys
-sys.path.append('..')
-sys.path.append('.')
-sys.path.append('tests/compare-pdf/compare_pdf') # used if compare_pdf has not been pip installed
-
+from pathlib import Path
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+from testutils import configureTestImportPaths
+configureTestImportPaths(__file__)
 # Parse the mcf file to create variations using xml.dom.minidom rather than xml.etree.ElementTree
 # Copilot suggested this choice because etree is bad at parsing CDATA
 from xml.dom.minidom import parse, Document
 
 from datetime import datetime
-from pathlib import Path
 from pikepdf import Pdf
 
 from compare_pdf import ComparePDF, ShowDiffsStyle # type: ignore

--- a/tests/testTabs/test_tabs.py
+++ b/tests/testTabs/test_tabs.py
@@ -2,13 +2,13 @@
 
 import os
 import sys
-from datetime import datetime
 from pathlib import Path
+from datetime import datetime
 
-sys.path.append('..')
-sys.path.append('.')
-sys.path.append('tests/compare-pdf/compare_pdf')
-
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+from testutils import configureTestImportPaths
+configureTestImportPaths(__file__)
 from pikepdf import Pdf
 
 from compare_pdf import ComparePDF, ShowDiffsStyle  # type: ignore

--- a/tests/testTextArt/test_textart.py
+++ b/tests/testTextArt/test_textart.py
@@ -3,19 +3,19 @@
 
 # Test of text art (curved baseline text)
 
-#if you run this file directly, it won't have access to parent folder, so add it to python path
+# Bootstrap the project root so this test can also run directly.
 import os, os.path
 import sys
-sys.path.append('..')
-sys.path.append('.')
-sys.path.append('tests/compare-pdf/compare_pdf') # used if compare_pdf has not been pip installed
-
+from pathlib import Path
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+from testutils import configureTestImportPaths
+configureTestImportPaths(__file__)
 # Parse the mcf file to create variations using xml.dom.minidom rather than xml.etree.ElementTree
 # Copilot suggested this choice because etree is bad at parsing CDATA
 from xml.dom.minidom import parse, Document
 
 from datetime import datetime
-from pathlib import Path
 from pikepdf import Pdf
 
 from compare_pdf import ComparePDF, ShowDiffsStyle # type: ignore

--- a/tests/testTextBox/test_textBox.py
+++ b/tests/testTextBox/test_textBox.py
@@ -3,15 +3,15 @@
 
 # Test the default substitution for missing fonts
 
-#if you run this file directly, it won't have access to parent folder, so add it to python path
+# Bootstrap the project root so this test can also run directly.
 import os, os.path
 import sys
-sys.path.append('..')
-sys.path.append('.')
-sys.path.append('tests/compare-pdf/compare_pdf') # used if compare_pdf has not been pip installed
-
-from datetime import datetime
 from pathlib import Path
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+from testutils import configureTestImportPaths
+configureTestImportPaths(__file__)
+from datetime import datetime
 from pikepdf import Pdf
 
 from compare_pdf import ComparePDF, ShowDiffsStyle # type: ignore

--- a/tests/testTextOutlines/test_textOutlines.py
+++ b/tests/testTextOutlines/test_textOutlines.py
@@ -3,13 +3,13 @@
 
 import os
 import sys
-from datetime import datetime
 from pathlib import Path
+from datetime import datetime
 
-sys.path.append('..')
-sys.path.append('.')
-sys.path.append('tests/compare-pdf/compare_pdf')
-
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+from testutils import configureTestImportPaths
+configureTestImportPaths(__file__)
 from pikepdf import Pdf
 
 from compare_pdf import ComparePDF, ShowDiffsStyle  # type: ignore

--- a/tests/testTextWrapVAlignBorder/test_textwrapvalignborder.py
+++ b/tests/testTextWrapVAlignBorder/test_textwrapvalignborder.py
@@ -3,19 +3,19 @@
 
 # Test of various object decorations
 
-#if you run this file directly, it won't have access to parent folder, so add it to python path
+# Bootstrap the project root so this test can also run directly.
 import os, os.path
 import sys
-sys.path.append('..')
-sys.path.append('.')
-sys.path.append('tests/compare-pdf/compare_pdf') # used if compare_pdf has not been pip installed
-
+from pathlib import Path
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+from testutils import configureTestImportPaths
+configureTestImportPaths(__file__)
 # Parse the mcf file to create variations using xml.dom.minidom rather than xml.etree.ElementTree
 # Copilot suggested this choice because etree is bad at parsing CDATA
 from xml.dom.minidom import parse, Document
 
 from datetime import datetime
-from pathlib import Path
 from pikepdf import Pdf
 
 from compare_pdf import ComparePDF, ShowDiffsStyle # type: ignore

--- a/tests/testTransparency/test_transparency.py
+++ b/tests/testTransparency/test_transparency.py
@@ -3,13 +3,13 @@
 
 import os
 import sys
-from datetime import datetime
 from pathlib import Path
+from datetime import datetime
 
-sys.path.append('..')
-sys.path.append('.')
-sys.path.append('tests/compare-pdf/compare_pdf')
-
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+from testutils import configureTestImportPaths
+configureTestImportPaths(__file__)
 from pikepdf import Pdf
 
 from compare_pdf import ComparePDF, ShowDiffsStyle  # type: ignore

--- a/tests/testbackgrounds/test_backgrounds.py
+++ b/tests/testbackgrounds/test_backgrounds.py
@@ -3,15 +3,15 @@
 
 # Test backgrounds
 
-#if you run this file directly, it won't have access to parent folder, so add it to python path
+# Bootstrap the project root so this test can also run directly.
 import os, os.path
 import sys
-sys.path.append('..')
-sys.path.append('.')
-sys.path.append('tests/compare-pdf/compare_pdf') # used if compare_pdf has not been pip installed
-
-from datetime import datetime
 from pathlib import Path
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+from testutils import configureTestImportPaths
+configureTestImportPaths(__file__)
+from datetime import datetime
 from pikepdf import Pdf, PdfImage
 
 from compare_pdf import ComparePDF, ShowDiffsStyle # type: ignore

--- a/tests/unittest_fotobook/test_simpleBook.py
+++ b/tests/unittest_fotobook/test_simpleBook.py
@@ -4,15 +4,15 @@
 #Copyright (c) 2019, 2020 by BarchSteel
 
 # test to convert a simple mcf to pdf
-#if you run this file directly, it won't have access to parent folder, so add it to python path
+# Bootstrap the project root so this test can also run directly.
 import os, os.path
 import sys
-sys.path.append('..')
-sys.path.append('.')
-sys.path.append('tests/compare-pdf/compare_pdf') # used if compare_pdf has not been pip installed
-
-from datetime import datetime
 from pathlib import Path
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+from testutils import configureTestImportPaths
+configureTestImportPaths(__file__)
+from datetime import datetime
 from pikepdf import Pdf
 
 from compare_pdf import ComparePDF, ShowDiffsStyle # type: ignore

--- a/testutils.py
+++ b/testutils.py
@@ -1,9 +1,34 @@
 import glob
 import os
 import os.path
+import sys
 
 from pathlib import Path
 from extraLoggers import mustsee
+
+
+def configureTestImportPaths(testFile):
+    """Make project modules and the local compare_pdf helper importable.
+
+    Tests are useful both through pytest and when a developer executes one
+    test file directly.  The latter has the test's directory, rather than the
+    repository root, on ``sys.path``.  Deriving paths from ``testFile`` avoids
+    depending on the current working directory used by Visual Studio, pytest,
+    or a command prompt.
+
+    The local compare_pdf directory is retained as a fallback for developers
+    who have not installed that helper package.  Both paths are inserted ahead
+    of installed packages so the test always exercises this working tree.
+    """
+    projectRoot = Path(testFile).resolve().parents[2]
+    comparePdfPath = projectRoot / 'tests' / 'compare-pdf' / 'compare_pdf'
+
+    for importPath in reversed((projectRoot, comparePdfPath)):
+        importPathText = str(importPath)
+        if importPathText in sys.path:
+            sys.path.remove(importPathText)
+        sys.path.insert(0, importPathText)
+
 
 def getLatestResultFile(albumFolderBasename, pattern: str) -> str:
     resultpdfpattern = str(Path(Path.cwd(), 'tests', f"{albumFolderBasename}", 'previous_result_pdfs', pattern))

--- a/textareas.py
+++ b/textareas.py
@@ -15,7 +15,6 @@ import reportlab.lib.colors
 import reportlab.lib.enums
 import reportlab.lib.pagesizes
 from reportlab.pdfbase import pdfmetrics
-from reportlab.lib.styles import ParagraphStyle
 from lxml import etree
 
 from borders import processDecorationBorders
@@ -32,6 +31,7 @@ from text import (AppendItemTextInStyle, AppendSpanEnd, AppendSpanStart, AppendT
 from textart import handleTextArt
 from textoutlines import TextEffectsParagraph, getTextOutline
 from texttabs import getTabbedTextLine
+from textlists import processTextLists
 from textspacing import getLetterSpacing
 
 
@@ -738,142 +738,3 @@ def processTextCore(pdf_flowableList, pdf_styleN, forceLeading, additional_fonts
     return textWrapProblem, indexEntryText, finalTotalHeight, frameBottomLeft_x, frameBottomLeft_y, frameHeight, frameWidth, recentParagraphText
 
 
-def processTextLists(pdf_flowableList, forceLeading, paragraphText: str, additional_fonts, body,  # noqa: C901
-        bodyfont: str | Any, bodyfs: int, bstyle: dict[Any, Any], bweight: int, pdf,
-        pdf_styleN, fontScaleFactor: float, unprocessed_children: set[Any], line_scales,
-        state: ConversionState) -> str:
-    """Convert CEWE's imported HTML ``ul`` and ``ol`` elements to paragraphs.
-
-    The Album Editor emits lists when text has been pasted from another
-    application. ReportLab's Paragraph supports the required wrapping, so we
-    supply each marker as part of a paragraph and use a hanging indent for any
-    continuation lines.
-    """
-    htmllists = body.findall("ul") + body.findall("ol")
-
-    for htmlList in htmllists:
-        # Mark this list as processed
-        unprocessed_children.discard(htmlList)
-
-        listitems = htmlList.findall("li")
-        try:
-            listNumber = int(htmlList.get('start', '1'))
-        except ValueError:
-            logging.warning(f"Ignoring invalid ordered-list start value {htmlList.get('start')}")
-            listNumber = 1
-
-        for li in listitems:
-            maxfs = 0
-
-            # Create a copy of the style for this list item with hanging indent
-            list_styleN = ParagraphStyle('list_item', parent=pdf_styleN)
-            # Hanging indent: first line at 0, subsequent lines indented
-            # Calculate indent based on font size - approximately 2x the font size
-            # accounts for bullet width + space
-            bullet_indent = bodyfs * 1.65  # Adjust multiplier if needed (1.5 - 2.5 range)
-            list_styleN.leftIndent = bullet_indent  # Where wrapped lines start
-            list_styleN.firstLineIndent = -bullet_indent / 2  # Pull first line (with bullet) back halfway position 0
-            bullet_txt = '• '
-            markerText = f'{listNumber}. ' if htmlList.tag == 'ol' else bullet_txt
-            listNumber += 1
-
-            # Check alignment (though lists are typically left-aligned)
-            if li.get('align') == 'center':
-                list_styleN.alignment = reportlab.lib.enums.TA_CENTER
-            elif li.get('align') == 'right':
-                list_styleN.alignment = reportlab.lib.enums.TA_RIGHT
-            elif li.get('align') == 'justify':
-                list_styleN.alignment = reportlab.lib.enums.TA_JUSTIFY
-            else:
-                list_styleN.alignment = reportlab.lib.enums.TA_LEFT
-
-            # Get line height from <li> style if present
-            pLineHeight = 1.0
-            liStyleAttribute = li.get('style')
-            if liStyleAttribute is not None:
-                liStyle = dict([kv.split(':') for kv in
-                                li.get('style').lstrip(' ').rstrip(';').split('; ')])
-                if 'line-height' in liStyle.keys():
-                    try:
-                        pLineHeight = floor(float(liStyle['line-height'].strip("%"))) / 100.0
-                    except:  # noqa: E722
-                        logging.warning(f"Ignoring invalid list item line-height setting {liStyleAttribute}")
-            finalLeadingFactor = line_scales.lineScaleForFont(bodyfont) * pLineHeight
-
-            # Start paragraph - we'll add bullet inside the styled text
-            paragraphText = '<para autoLeading="max">'
-
-            # Check if there are child elements (spans, br, etc.)
-            lispans = li.findall(".*")
-
-            if len(lispans) < 1:
-                # Simple list item with just text, no spans
-                # Prepend bullet to the text so it gets styled
-                marker_plus_text = markerText + (li.text if li.text is not None else "")
-                paragraphText, maxfs = AppendItemTextInStyle(paragraphText, marker_plus_text, li, pdf,
-                                                             additional_fonts, bodyfont, bodyfs, bweight, bstyle, fontScaleFactor, state)
-                paragraphText += '</para>'
-                usefs = maxfs if maxfs > 0 else bodyfs
-                list_styleN.leading = usefs * forceLeading if forceLeading is not None else usefs * finalLeadingFactor
-                pdf_flowableList.append(TextEffectsParagraph(paragraphText, list_styleN))
-            else:
-                # List item with spans and other formatting
-                marker_plus_text = markerText + (li.text if li.text is not None else "")
-                paragraphText, maxfs = AppendItemTextInStyle(paragraphText, marker_plus_text, li, pdf,
-                                                             additional_fonts, bodyfont, bodyfs, bweight, bstyle, fontScaleFactor, state)
-                usefs = maxfs if maxfs > 0 else bodyfs
-                list_styleN.leading = usefs * forceLeading if forceLeading is not None else usefs * finalLeadingFactor
-
-                # Process child elements (spans, br, etc.)
-                for item in lispans:
-                    if item.tag == 'br':
-                        br = item
-                        # For lists, we don't typically break into multiple paragraphs on <br>
-                        # Instead, insert a line break within the same paragraph
-                        paragraphText += '<br/>'
-                        if br.tail:
-                            paragraphText, maxfs = AppendItemTextInStyle(paragraphText, br.tail, li, pdf,
-                                                                         additional_fonts, bodyfont, bodyfs, bweight,
-                                                                         bstyle, fontScaleFactor, state)
-
-                    elif item.tag == 'span':
-                        span = item
-                        spanfont, spanfs, spanweight, spanstyle = CollectFontInfo(span, pdf, additional_fonts, bodyfont,
-                                                                                  bodyfs, bweight, fontScaleFactor, state)
-
-                        maxfs = max(maxfs, spanfs)
-
-                        paragraphText = AppendSpanStart(paragraphText, spanfont, spanfs, spanweight, spanstyle, bstyle)
-
-                        if span.text is not None:
-                            paragraphText = AppendText(paragraphText, html.escape(span.text))
-
-                        # Handle line breaks within spans
-                        brs = span.findall(".//br")
-                        if len(brs) > 0:
-                            paragraphText = AppendSpanEnd(paragraphText, spanweight, spanstyle, bstyle)
-                            for br in brs:
-                                paragraphText += '<br/>'
-                                if br.tail:
-                                    paragraphText, maxfs = AppendItemTextInStyle(paragraphText, br.tail, span, pdf,
-                                                                                 additional_fonts, bodyfont, bodyfs,
-                                                                                 bweight, bstyle, fontScaleFactor, state)
-                        else:
-                            paragraphText = AppendSpanEnd(paragraphText, spanweight, spanstyle, bstyle)
-
-                        if span.tail is not None:
-                            paragraphText = AppendText(paragraphText, html.escape(span.tail))
-
-                    else:
-                        logging.warning(
-                            f"Ignoring unhandled tag {item.tag} in list item (tag content: {etree.tostring(item, encoding='unicode')[:100]}...)")
-
-                # Finalize the list item paragraph
-                try:
-                    paragraphText += '</para>'
-                    usefs = maxfs if maxfs > 0 else bodyfs
-                    list_styleN.leading = usefs * forceLeading if forceLeading is not None else usefs * finalLeadingFactor
-                    pdf_flowableList.append(TextEffectsParagraph(paragraphText, list_styleN))
-                except Exception:
-                    logging.exception('Exception')
-    return paragraphText

--- a/textlists.py
+++ b/textlists.py
@@ -1,0 +1,133 @@
+"""Support for simple HTML lists imported into CEWE text areas.
+
+CEWE creates ``ul`` and ``ol`` elements when a list is pasted from another
+application.  Its editor does not offer equivalent list creation tools, and
+the exact marker positioning is not documented.  This module deliberately
+supports only the flat imported lists currently observed in MCF files.
+"""
+
+# List processing receives the same text-rendering inputs as ordinary
+# paragraphs so it can honour fonts, line scales, outlines and shrink retries.
+# Keeping that interface avoids a second, subtly different text pipeline.
+# pylint: disable=too-many-arguments,too-many-locals,too-many-nested-blocks
+# pylint: disable=too-many-branches,too-many-statements
+
+import html
+import logging
+from math import floor
+from typing import Any
+
+import reportlab.lib.enums
+from lxml import etree
+from reportlab.lib.styles import ParagraphStyle
+
+from conversionState import ConversionState
+from text import (AppendItemTextInStyle, AppendSpanEnd, AppendSpanStart,
+                  AppendText, CollectFontInfo)
+from textoutlines import TextEffectsParagraph
+
+
+def processTextLists(pdf_flowableList, forceLeading, paragraphText: str, additional_fonts, body,  # noqa: C901
+                     bodyfont: str | Any, bodyfs: int, bstyle: dict[Any, Any], bweight: int, pdf,
+                     pdf_styleN, fontScaleFactor: float, unprocessed_children: set[Any], line_scales,
+                     state: ConversionState) -> str:
+    """Convert CEWE's imported HTML ``ul`` and ``ol`` elements to paragraphs.
+
+    A marker is added to each ReportLab Paragraph and a hanging indent keeps
+    continuation lines aligned.  Nested lists and non-standard list markers
+    are intentionally left for the ordinary HTML path until real examples
+    justify more elaborate handling.
+    """
+    htmlLists = body.findall("ul") + body.findall("ol")
+
+    for htmlList in htmlLists:
+        unprocessed_children.discard(htmlList)
+
+        listItems = htmlList.findall("li")
+        try:
+            listNumber = int(htmlList.get('start', '1'))
+        except ValueError:
+            logging.warning(f"Ignoring invalid ordered-list start value {htmlList.get('start')}")
+            listNumber = 1
+
+        for listItem in listItems:
+            maxFontSize = 0
+
+            listStyle = ParagraphStyle('list_item', parent=pdf_styleN)
+            markerIndent = bodyfs * 1.65
+            listStyle.leftIndent = markerIndent
+            listStyle.firstLineIndent = -markerIndent / 2
+            markerText = f'{listNumber}. ' if htmlList.tag == 'ol' else '• '
+            listNumber += 1
+
+            if listItem.get('align') == 'center':
+                listStyle.alignment = reportlab.lib.enums.TA_CENTER
+            elif listItem.get('align') == 'right':
+                listStyle.alignment = reportlab.lib.enums.TA_RIGHT
+            elif listItem.get('align') == 'justify':
+                listStyle.alignment = reportlab.lib.enums.TA_JUSTIFY
+            else:
+                listStyle.alignment = reportlab.lib.enums.TA_LEFT
+
+            lineHeight = 1.0
+            itemStyleAttribute = listItem.get('style')
+            if itemStyleAttribute is not None:
+                itemStyle = dict(kv.split(':') for kv in
+                                 itemStyleAttribute.lstrip(' ').rstrip(';').split('; '))
+                if 'line-height' in itemStyle:
+                    try:
+                        lineHeight = floor(float(itemStyle['line-height'].strip('%'))) / 100.0
+                    except ValueError:
+                        logging.warning(f"Ignoring invalid list item line-height setting {itemStyleAttribute}")
+            leadingFactor = line_scales.lineScaleForFont(bodyfont) * lineHeight
+
+            paragraphText = '<para autoLeading="max">'
+            itemChildren = listItem.findall(".*")
+            markerPlusText = markerText + (listItem.text if listItem.text is not None else '')
+            paragraphText, maxFontSize = AppendItemTextInStyle(
+                paragraphText, markerPlusText, listItem, pdf, additional_fonts,
+                bodyfont, bodyfs, bweight, bstyle, fontScaleFactor, state)
+
+            for item in itemChildren:
+                if item.tag == 'br':
+                    paragraphText += '<br/>'
+                    if item.tail:
+                        paragraphText, maxFontSize = AppendItemTextInStyle(
+                            paragraphText, item.tail, listItem, pdf, additional_fonts,
+                            bodyfont, bodyfs, bweight, bstyle, fontScaleFactor, state)
+                elif item.tag == 'span':
+                    spanfont, spanfs, spanweight, spanstyle = CollectFontInfo(
+                        item, pdf, additional_fonts, bodyfont, bodyfs, bweight,
+                        fontScaleFactor, state)
+                    maxFontSize = max(maxFontSize, spanfs)
+                    paragraphText = AppendSpanStart(
+                        paragraphText, spanfont, spanfs, spanweight, spanstyle, bstyle)
+                    if item.text is not None:
+                        paragraphText = AppendText(paragraphText, html.escape(item.text))
+
+                    breaks = item.findall('.//br')
+                    if breaks:
+                        paragraphText = AppendSpanEnd(paragraphText, spanweight, spanstyle, bstyle)
+                        for lineBreak in breaks:
+                            paragraphText += '<br/>'
+                            if lineBreak.tail:
+                                paragraphText, maxFontSize = AppendItemTextInStyle(
+                                    paragraphText, lineBreak.tail, item, pdf, additional_fonts,
+                                    bodyfont, bodyfs, bweight, bstyle, fontScaleFactor, state)
+                    else:
+                        paragraphText = AppendSpanEnd(paragraphText, spanweight, spanstyle, bstyle)
+
+                    if item.tail is not None:
+                        paragraphText = AppendText(paragraphText, html.escape(item.tail))
+                else:
+                    logging.warning(
+                        f"Ignoring unhandled tag {item.tag} in list item "
+                        f"(tag content: {etree.tostring(item, encoding='unicode')[:100]}...)")
+
+            paragraphText += '</para>'
+            useFontSize = maxFontSize if maxFontSize > 0 else bodyfs
+            listStyle.leading = (useFontSize * forceLeading if forceLeading is not None
+                                 else useFontSize * leadingFactor)
+            pdf_flowableList.append(TextEffectsParagraph(paragraphText, listStyle))
+
+    return paragraphText


### PR DESCRIPTION
We avoid filling the prime textareas.py with stuff which is really extra to the basic functionality
The album conversion session ensures proper resource release in all cases
All tests import the correct path regardless of where the test is run from